### PR TITLE
implemented the hill/valley parameterization desribed by https://arxi…

### DIFF
--- a/cosmoprimo/__init__.py
+++ b/cosmoprimo/__init__.py
@@ -3,12 +3,14 @@ from .interpolator import PowerSpectrumInterpolator1D, PowerSpectrumInterpolator
 from .fftlog import FFTlog, PowerToCorrelation, CorrelationToPower, TophatVariance
 from .bao_filter import PowerSpectrumBAOFilter, CorrelationFunctionBAOFilter
 from . import fiducial
+from . import mochiclass_stability, heftcamb_stability
 
 __all__ = ['Cosmology', 'Background', 'Thermodynamics', 'Primordial', 'Transfer', 'Harmonic', 'Fourier', 'CosmologyError']
 __all__ += ['PowerSpectrumInterpolator1D', 'PowerSpectrumInterpolator2D', 'CorrelationFunctionInterpolator1D', 'CorrelationFunctionInterpolator2D']
 __all__ += ['FFTlog', 'PowerToCorrelation', 'CorrelationToPower', 'TophatVariance']
 __all__ += ['PowerSpectrumBAOFilter', 'CorrelationFunctionBAOFilter']
 __all__ += ['fiducial']
+__all__ += ['mochiclass_stability', 'heftcamb_stability']
 
 
 import importlib.metadata

--- a/cosmoprimo/heftcamb.py
+++ b/cosmoprimo/heftcamb.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .camb import (CambEngine, Background as CambBackground, Thermodynamics, Primordial,
                    Transfer, Harmonic, Fourier)
-from .cosmology import CosmologyComputationError
+from .cosmology import CosmologyComputationError, CosmologyInputError
 from . import utils, constants
 
 
@@ -141,7 +141,24 @@ _DESIGNER_NORMALISATION_OK = None
 
 
 class Background(CambBackground):
-    """CAMB background section, with the GR-only growth solver disabled.
+    r"""CAMB background section, with the GR-only growth solver disabled, and with the
+    Horndeski / EFT-of-dark-energy functions :math:`h_{1}`, :math:`h_{3}` and :math:`h_{5}`
+    of `arXiv:2312.10510 <https://arxiv.org/abs/2312.10510>`_ (eqs. A.8, A.9, A.10; eqs. 64,
+    66, 68 of `arXiv:1902.06978 <https://arxiv.org/abs/1902.06978>`_), which parameterize the
+    quasi-static effective Newton constant
+
+    .. math:: Y(k, z) = h_{1} \frac{1 + k^{2} h_{5}}{1 + k^{2} h_{3}}.
+
+    :math:`h_{1}`, :math:`h_{3}` and :math:`h_{5}` are functions of
+    :math:`\eta = \ln a = -\ln (1 + z)`, the time variable Horndeski / EFT-of-dark-energy
+    codes (e.g. fkptjax) integrate in; :meth:`Y` keeps taking a redshift.  This is the same
+    API, in the same units and conventions, as the 'mochiclass' engine, e.g.::
+
+        common = dict(c_K=1., c_B=2., c_M=2., c_T=0., M2_ini=1., w0_fld=-1., wa_fld=0.)
+        cosmo = AbacusSummit(0, engine='heftcamb', **common)
+        cosmo.h1(eta), cosmo.h3(eta), cosmo.h5(eta), cosmo.Y(k, z)
+
+    On the GR-only growth solver:
 
     Recent cosmoprimo gives ``camb.Background`` a ``growth_factor`` /
     ``growth_rate`` that integrates the *general relativistic* growth equation
@@ -183,6 +200,127 @@ class Background(CambBackground):
     def growth_rate(self, z, mass='m'):
         self._check_gr_growth('growth_rate')
         return super().growth_rate(z, mass=mass)
+
+    # ------------------------------------------------------------------
+    # Horndeski / EFT-of-dark-energy one-loop kernels.
+    #
+    # Same API as the 'mochiclass' engine (see mochiclassy.Background), so
+    # that h1 / h3 / h5 / Y can be requested from either engine with the
+    # same call.  Here they are not rebuilt from the alpha-functions: the
+    # patched HEFTCAMB computes them itself, in EFTCAMBModelComputeOneLoopKernels
+    # (fortran/eftcamb/06_abstract_EFTCAMB_model.f90), in cancellation-free
+    # form, and exposes them in the timestep cache as h1_loop, h3_loop,
+    # h5_loop.  This just evaluates that cache on the requested times.
+    # ------------------------------------------------------------------
+
+    # Requested name -> HEFTCAMB timestep-cache field.  alpha_B, xi and aH
+    # are derived below; the rest are copied straight over.  Names and
+    # conventions follow mochiclassy.Background._eft_of_de_at_eta.
+    _eft_of_de_fields = {'M2': 'Meff2',
+                         'alpha_M': 'alphaM',
+                         'alpha_T': 'alphaT',
+                         'alpha_K': 'alphaK',
+                         'alpha_1': 'a1_loop',
+                         'alpha_2': 'a2_loop',
+                         'mu2': 'mu2_loop',
+                         'h1': 'h1_loop',
+                         'h3': 'h3_loop',
+                         'h5': 'h5_loop'}
+
+    def _eft_of_de_at_eta(self, eta):
+        r"""
+        Return dict of the background quantities entering eqs. (A.9) - (A.13) of
+        arXiv:2312.10510 (eqs. 62 - 69 of arXiv:1902.06978), evaluated at
+        :math:`\eta = \ln a`.
+
+        Everything comes from HEFTCAMB's own timestep cache, i.e. from the same
+        numbers the perturbation solver uses; nothing is finite-differenced or
+        re-interpolated here.  :math:`\alpha_{B}` is returned in the hi_class /
+        mochi-class convention (:attr:`BRAIDING_EFTCAMB_OVER_HICLASS`), which is
+        the one eqs. (A.12) - (A.13) are written in, so the dict is directly
+        comparable with the mochiclass one.
+
+        The result of the last call is cached, so asking for :meth:`h1`,
+        :meth:`h3` and :meth:`h5` on the same times costs one HEFTCAMB call, not
+        three.
+        """
+        eta = np.asarray(eta, dtype='f8').ravel()
+        cache = getattr(self, '_eft_of_de_cache', None)
+        key = (eta.shape, eta.tobytes())
+        if cache is not None and cache[0] == key:
+            return cache[1]
+
+        eftcamb = self._engine._camb_params.EFTCAMB
+        if eftcamb is None:
+            raise CosmologyInputError('HEFTCAMB did not set up an EFT model; h1 / h3 / h5 require '
+                                      'the EFT sector, i.e. EFTflag != 0 among the engine parameters')
+        fields, values = eftcamb.get_eft_functions(self.ba, np.exp(eta))
+        for name in self._eft_of_de_fields.values():
+            if name not in fields:
+                raise CosmologyInputError('HEFTCAMB did not output "{}"; h1 / h3 / h5 require the build '
+                                          'carrying the one-loop-kernel patch'.format(name))
+        toret = {name: np.asarray(values[field], dtype='f8') for name, field in self._eft_of_de_fields.items()}
+        # Appendix-A / hi_class braiding, alpha_B = -2 alpha_B^EFTCAMB.
+        toret['alpha_B'] = np.asarray(values['alphaB'], dtype='f8') / BRAIDING_EFTCAMB_OVER_HICLASS
+        # aH / c, in h / Mpc (HEFTCAMB's adotoa is a H / c in 1 / Mpc).
+        toret['aH'] = np.asarray(values['adotoa'], dtype='f8') / self.h
+        # xi = H' / H, with ' = d / dln a.
+        toret['xi'] = np.asarray(values['Hdot'], dtype='f8') / np.asarray(values['adotoa'], dtype='f8')**2 - 1.
+
+        self._eft_of_de_cache = (key, toret)
+        return toret
+
+    @utils.flatarray(dtype=np.float64)
+    def h1(self, eta):
+        r"""
+        :math:`h_{1} = (1 + \alpha_{T}) / M_{\ast}^{2}`, eq. (A.8) of arXiv:2312.10510
+        (eq. 64 of arXiv:1902.06978), unitless, as a function of :math:`\eta = \ln a`.
+        """
+        return self._eft_of_de_at_eta(eta)['h1']
+
+    @utils.flatarray(dtype=np.float64)
+    def h3(self, eta):
+        r"""
+        :math:`h_{3} = \left[(2 - \alpha_{B}) \alpha_{1} + 2 \alpha_{2}\right] / (2 a^{2} H^{2} \mu^{2})`,
+        eq. (A.9) of arXiv:2312.10510 (eq. 66 of arXiv:1902.06978), in
+        :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`),
+        as a function of :math:`\eta = \ln a`.
+        """
+        return self._eft_of_de_at_eta(eta)['h3']
+
+    @utils.flatarray(dtype=np.float64)
+    def h5(self, eta):
+        r"""
+        :math:`h_{5} = \left[\frac{1 + \alpha_{M}}{1 + \alpha_{T}} \alpha_{1} + \alpha_{2}\right] / (a^{2} H^{2} \mu^{2})`,
+        eq. (A.10) of arXiv:2312.10510 (eq. 68 of arXiv:1902.06978), in
+        :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`),
+        as a function of :math:`\eta = \ln a`.
+        """
+        return self._eft_of_de_at_eta(eta)['h5']
+
+    def Y(self, k, z):
+        r"""
+        Quasi-static effective Newton constant :math:`Y = h_{1} (1 + k^{2} h_{5}) / (1 + k^{2} h_{3})`,
+        eq. 24 of arXiv:1902.06978, unitless.
+
+        Parameters
+        ----------
+        k : array_like
+            Wavenumbers, in :math:`h/\mathrm{Mpc}`.
+
+        z : array_like
+            Redshifts.  Note :meth:`h1`, :meth:`h3` and :meth:`h5` themselves take
+            :math:`\eta = \ln a`; the conversion is done here.
+
+        Returns
+        -------
+        Y : array
+            Array of shape ``(k.shape, z.shape)``.
+        """
+        k, z = np.asarray(k, dtype='f8'), np.asarray(z, dtype='f8')
+        k2 = k.reshape(k.shape + (1,) * z.ndim)**2
+        eta = -np.log(1. + z)
+        return self.h1(eta) * (1. + k2 * self.h5(eta)) / (1. + k2 * self.h3(eta))
 
 
 class HEFTCAMBEngine(CambEngine):

--- a/cosmoprimo/heftcamb.py
+++ b/cosmoprimo/heftcamb.py
@@ -1,12 +1,128 @@
 """Cosmological calculation with the H-EFTCAMB version of CAMB."""
 
+import warnings
+
 import numpy as np
 
-from .camb import CambEngine, Background, Thermodynamics, Primordial, Transfer, Harmonic, Fourier
+from .camb import (CambEngine, Background as CambBackground, Thermodynamics, Primordial,
+                   Transfer, Harmonic, Fourier)
+from .cosmology import CosmologyComputationError
 from . import utils, constants
 
 
 np.int = int
+
+
+# ----------------------------------------------------------------------
+# EFTCAMB parametrized_function_1D model flags -> parameter name suffixes.
+#
+# A parametrized 1D function called NAME reads its parameters from the
+# (virtual) ini file under the names built by its `parameter_names`
+# routine in the Fortran source.  The default naming of
+# 04_abstract_parametrizations_1D.f90 is NAME0, NAME1, ...; some
+# parametrizations override it.
+#
+# This mapping is used to strip the shape parameters that the currently
+# selected model flag will NOT read.  This matters because HEFTCAMB's
+# `camb.set_params` marks as "used" only the keys the Fortran side
+# actually queried; anything left over raises CAMBUnknownArgumentError.
+# ----------------------------------------------------------------------
+_RPH_FLAG_PARAM_SUFFIXES = {
+    0: (),                          # zero
+    1: ('0',),                      # constant
+    2: ('0',),                      # linear
+    3: ('0', 'Exp'),                # power law
+    4: ('0', 'Exp'),                # exponential
+    8: ('_v1', '_v2', '_at', '_delta'),   # steplog
+    11: ('0', '1'),                 # exponential 2
+    12: ('_cM', '_at', '_tau'),     # hill/valley, Brando et al. JCAP 11 (2019) 018 eq. (3.2)
+}
+
+# w_DE parametrization flags of 007p2_RPH.f90 (these set explicit names).
+_RPH_WDE_FLAG_PARAMS = {
+    0: (),                                              # LCDM
+    1: ('RPHw0',),                                      # constant w
+    2: ('RPHw0', 'RPHwa'),                              # CPL
+    3: ('RPHw0', 'RPHwa', 'RPHwn'),                     # JBP
+    4: ('RPHw0', 'RPHwa', 'RPHwat'),                    # turning point
+    5: ('RPHw0', 'RPHwa', 'RPHw2', 'RPHw3'),            # Taylor
+}
+
+# (model flag name, name of the parametrized function on the Fortran side)
+# Branches that are always active.
+_RPH_COMMON_BRANCHES = (
+    ('RPHbraidingmodel', 'RPHbraiding'),
+    ('RPHbraidingmodel_ODE', 'RPHbraiding_ODE'),
+    ('RPHkineticitymodel', 'RPHkineticity'),
+    ('RPHkineticitymodel_ODE', 'RPHkineticity_ODE'),
+    ('RPHtensormodel', 'RPHtensor'),
+    ('RPHtensormodel_ODE', 'RPHtensor_ODE'),
+)
+
+# Read only when RPHusealphaM = True (007p2_RPH.f90,
+# EFTCAMBRPHInitModelParametersFromFile).
+_RPH_ALPHAM_BRANCHES = (
+    ('RPHalphaMmodel', 'RPHalphaM'),
+    ('RPHalphaMmodel_ODE', 'RPHalphaM_ODE'),
+)
+
+# Read only when RPHusealphaM = False.
+_RPH_MASSP_BRANCHES = (
+    ('RPHmassPmodel', 'RPHmassP'),
+    ('RPHmassPmodel_ODE', 'RPHmassP_ODE'),
+)
+
+_RPH_ALPHA_BRANCHES = _RPH_COMMON_BRANCHES + _RPH_ALPHAM_BRANCHES + _RPH_MASSP_BRANCHES
+
+# Model flag of the hill/valley parametrization added to
+# fortran/eftcamb/04f_parametrizations_1D/04p020_hillvalley_parametrizations_1D.f90
+# and registered as case(12) in 04p1_parametrizations_1D_allocator.f90.
+HILLVALLEY_FLAG = 12
+
+
+class Background(CambBackground):
+    """CAMB background section, with the GR-only growth solver disabled.
+
+    Recent cosmoprimo gives ``camb.Background`` a ``growth_factor`` /
+    ``growth_rate`` that integrates the *general relativistic* growth equation
+
+        D'' + [1 - (addot/a)/H^2] D' = (3/2) Omega_m(z) D
+
+    via ``DefaultBackground``, using cosmoprimo's analytic ``w0_fld`` /
+    ``wa_fld`` background. Both ingredients are wrong for an EFTCAMB run: the
+    source term carries no alpha_M / alpha_B modification of the Poisson
+    equation, and the expansion history is cosmoprimo's, not the one EFTCAMB
+    integrates from ``RPHwDE``. Since these methods are inherited silently,
+    they are blocked here rather than returning plausible but GR numbers.
+
+    Get the modified-gravity growth from the perturbations instead, e.g.
+
+        fo = cosmo.get_fourier()
+        f_sigma8 = fo.sigma8_z(z, of='theta_cb') / fo.sigma8_z(z, of='delta_cb')
+
+    Pass ``heftcamb_gr_growth=True`` in ``extra_params`` to re-enable the GR
+    computation (for instance to compare against a GR reference).
+    """
+
+    def _check_gr_growth(self, name):
+        if getattr(self._engine, '_heftcamb_gr_growth', False):
+            return
+        raise CosmologyComputationError(
+            "Background.{}() on the 'heftcamb' engine would solve the general relativistic "
+            "growth ODE on cosmoprimo's (w0_fld, wa_fld) background, ignoring the EFTCAMB "
+            "modification of gravity and of the expansion history; the result would not "
+            "describe this model. Use the perturbations instead, e.g. "
+            "fo = cosmo.get_fourier(); fo.sigma8_z(z, of='theta_cb') / fo.sigma8_z(z, of='delta_cb'), "
+            "or pass heftcamb_gr_growth=True to force the GR calculation.".format(name)
+        )
+
+    def growth_factor(self, z, mass='m', znorm=None):
+        self._check_gr_growth('growth_factor')
+        return super().growth_factor(z, mass=mass, znorm=znorm)
+
+    def growth_rate(self, z, mass='m'):
+        self._check_gr_growth('growth_rate')
+        return super().growth_rate(z, mass=mass)
 
 
 class HEFTCAMBEngine(CambEngine):
@@ -24,6 +140,23 @@ class HEFTCAMBEngine(CambEngine):
     omega_cdm, h, n_s, etc. here. CambEngine already handles those and maps
     them to CAMB names. Putting them here can forward logA directly to
     camb.set_params(...), causing CAMBUnknownArgumentError.
+
+    Two alpha-function shapes are wired up here:
+
+      - the default one, alpha_X(a) = cX * Omega_DE(a), obtained with
+        RPHXmodel = 0 and RPHXmodel_ODE = 2;
+
+      - the "hill/valley" shape of Brando, Falciano, Linder & Velten,
+        JCAP 11 (2019) 018, eq. (3.2),
+
+            alpha(a) = c tanh[(tau/2) ln(a/a_t)] / cosh^2[(tau/2) ln(a/a_t)]
+
+        obtained with RPHXmodel = 12 and the three parameters
+        RPHX_cM, RPHX_at, RPHX_tau.  This requires the patched HEFTCAMB
+        build that provides parametrization flag 12.
+
+    Shape parameters that the selected model flag would not read are
+    stripped before reaching camb.set_params(...); see _prune_rph_params.
     """
 
     name = "heftcamb"
@@ -35,6 +168,8 @@ class HEFTCAMBEngine(CambEngine):
     # These are accepted by HEFTCAMB's camb.set_params(...).
     # ------------------------------------------------------------------
     _default_cosmological_parameters = dict(
+        # --- alpha_X(a) = RPHX_ODE0 * Omega_DE(a)  (RPHXmodel_ODE = 2) ---
+
         # alpha_K(a) = RPHkineticity_ODE0 * Omega_DE(a)
         RPHkineticity_ODE0=1.0,
 
@@ -46,6 +181,17 @@ class HEFTCAMBEngine(CambEngine):
 
         # alpha_T(a) = RPHtensor_ODE0 * Omega_DE(a)
         RPHtensor_ODE0=0.0,
+
+        # --- hill/valley shape (RPHXmodel = 12), eq. (3.2) of
+        # --- Brando et al. JCAP 11 (2019) 018.  Only forwarded to
+        # --- HEFTCAMB when the corresponding model flag is 12.
+        RPHalphaM_cM=0.0,
+        RPHalphaM_at=0.5,
+        RPHalphaM_tau=1.0,
+
+        RPHbraiding_cM=0.0,
+        RPHbraiding_at=0.5,
+        RPHbraiding_tau=1.0,
     )
 
     # ------------------------------------------------------------------
@@ -77,6 +223,11 @@ class HEFTCAMBEngine(CambEngine):
         RPHintegratefromtoday=False,
         RPHusealphaM=True,
 
+        # Initial condition of the M^2 ODE:
+        # 1 + RPH_M0 = M_eff^2 / m_0^2 at the starting time of the
+        # integration (early times when RPHintegratefromtoday = False).
+        RPH_M0=0.0,
+
         # alpha_K branch
         RPHkineticitymodel=0,
         RPHkineticitymodel_ODE=2,
@@ -99,6 +250,8 @@ class HEFTCAMBEngine(CambEngine):
         "eftcamb_params",
         "eftcamb_print_header",
         "heftcamb_debug",
+        "heftcamb_map_w0wa",
+        "heftcamb_gr_growth",
         "RPH_massP0",
         "RPH_braiding0",
         "RPH_kinetic0",
@@ -111,6 +264,22 @@ class HEFTCAMBEngine(CambEngine):
         eftcamb_params = kwargs.pop("eftcamb_params", None)
         eftcamb_print_header = kwargs.pop("eftcamb_print_header", False)
         heftcamb_debug = kwargs.pop("heftcamb_debug", eftcamb_print_header)
+
+        # Whether to translate cosmoprimo's (w0_fld, wa_fld) into the
+        # EFTCAMB background parametrization (RPHwDE / RPHw0 / RPHwa).
+        # Without this, w0_fld/wa_fld are silently ignored by EFTCAMB,
+        # which drives its own background from RPHwDE.
+        heftcamb_map_w0wa = kwargs.pop("heftcamb_map_w0wa", True)
+
+        # Allow the GR growth ODE of Background.growth_factor / growth_rate,
+        # which does not describe the modified gravity model (see Background).
+        heftcamb_gr_growth = kwargs.pop("heftcamb_gr_growth", False)
+
+        # Stash on self: _set_camb() runs inside super().__init__().
+        self._heftcamb_debug = bool(heftcamb_debug)
+        self._heftcamb_map_w0wa = bool(heftcamb_map_w0wa)
+        self._heftcamb_gr_growth = bool(heftcamb_gr_growth)
+        self._pruned_rph_params = {}
 
         # Convenience aliases.
         # Use None defaults so these aliases do not accidentally overwrite
@@ -151,17 +320,235 @@ class HEFTCAMBEngine(CambEngine):
         for key in self._wrapper_private_keys:
             kwargs.pop(key, None)
 
+        # Remember whether flag 12 was asked for, so that a failure can be
+        # attributed to a HEFTCAMB build without the hill/valley parametrization.
+        self._hillvalley_in_kwargs = False
+        for flag_name, _ in _RPH_ALPHA_BRANCHES:
+            try:
+                if int(kwargs.get(flag_name, 0)) == HILLVALLEY_FLAG:
+                    self._hillvalley_in_kwargs = True
+                    break
+            except (TypeError, ValueError):
+                continue
+
         if heftcamb_debug:
             self._debug_kwargs_before_super(kwargs)
 
         # Parent CambEngine now sees the complete HEFTCAMB parameter set.
-        super().__init__(*args, **kwargs)
+        try:
+            super().__init__(*args, **kwargs)
+        except Exception as exc:
+            raise self._annotate_init_error(exc) from exc
 
         # read_parameters() is cached Python-side; clear before debug.
         self._clear_eftcamb_read_cache()
 
         if heftcamb_debug:
             self._debug_eftcamb_parameters("after CambEngine")
+
+    # ------------------------------------------------------------------
+    # RPH parameter bookkeeping
+    # ------------------------------------------------------------------
+    def _rph_setting(self, name, default=0):
+        """Value of an EFTCAMB switch as it will be seen by set_params.
+
+        ``CambEngine`` builds ``all_params = self._extra_params | base_params``
+        with ``base_params`` derived from ``self._params``, so ``self._params``
+        has priority.
+        """
+        for container in (getattr(self, '_params', {}), getattr(self, '_extra_params', {})):
+            if name in container:
+                return container[name]
+        return self._default_calculation_parameters.get(name, default)
+
+    def _resolve_default_param_conflicts(self):
+        """Let explicit ``extra_params`` win over untouched class defaults.
+
+        ``BaseEngine.__init__`` merges *both* ``_default_cosmological_parameters``
+        and ``_default_calculation_parameters`` into ``self._params``, while
+        anything the user passes as ``extra_params`` lands in
+        ``self._extra_params``. ``CambEngine`` then builds
+        ``all_params = self._extra_params | base_params`` with ``base_params``
+        derived from ``self._params``, so ``self._params`` wins.
+
+        The consequence is that an engine switch such as ``RPHalphaMmodel``,
+        which has a class default of 0, keeps that default even when the user
+        writes ``extra_params={'RPHalphaMmodel': 12}``: the class default in
+        ``self._params`` overrides the explicit request. When the value in
+        ``self._params`` is still the untouched class default and
+        ``extra_params`` carries something else, the latter is used.
+
+        A value set directly on the ``Cosmology`` (so that ``self._params``
+        differs from the class default) still has the last word.
+        """
+        defaults = dict(self._default_calculation_parameters)
+        defaults.update(self._default_cosmological_parameters)
+        for key, default in defaults.items():
+            if key in self._params and key in self._extra_params:
+                if self._params[key] == default and self._extra_params[key] != default:
+                    self._params.pop(key)
+
+    def _eftcamb_drives_background(self):
+        """Whether EFTCAMB, rather than CAMB's DarkEnergy, sets the background."""
+        try:
+            return int(self._rph_setting('EFTflag', 0)) != 0
+        except (TypeError, ValueError):
+            return False
+
+    @property
+    def _has_fld(self):
+        r"""Report no CAMB fluid dark energy while EFTCAMB drives the background.
+
+        ``CambEngine.__init__`` forwards ``(w0_fld, wa_fld, cs2_fld)`` to
+        ``cp.DarkEnergy.set_params`` only when ``_has_fld`` is true. With
+        ``dark_energy_model = 'EFTCAMB'``, HEFTCAMB's ``set_classes`` allocates a
+        *fluid* ``DarkEnergy`` object that EFTCAMB then never uses: whenever
+        ``EFTFlag /= 0``, ``dtauda`` and the perturbation equations in
+        equations.f90 set ``grhov_t = 0`` and take the dark energy density from
+        the EFTCAMB cache instead, which the RPH model integrates from
+        ``RPHwDE``. That unused fluid object is nevertheless validated, and
+        ``DarkEnergyFluid.validate_params`` raises "fluid dark energy model does
+        not support w crossing -1" for any phantom-crossing CPL -- including the
+        mirage line w_a = -3.6 (1 + w_0) of Brando et al., for which
+        1 + w_0 + w_a < 0.
+
+        The equation of state is not lost: :meth:`_map_w0wa_to_rph` has already
+        copied it into ``RPHwDE`` / ``RPHw0`` / ``RPHwa``, and ``self._params``
+        keeps ``w0_fld`` / ``wa_fld`` untouched, so cosmoprimo's own bookkeeping
+        and the CAMB-derived background quantities are unaffected.
+        """
+        if self._eftcamb_drives_background():
+            return False
+        return CambEngine._has_fld.fget(self)
+
+    def _check_background_consistency(self):
+        """Warn if a non-trivial w(a) would be dropped on both sides."""
+        if not self._eftcamb_drives_background():
+            return
+        w0 = float(self._params.get('w0_fld', -1.))
+        wa = float(self._params.get('wa_fld', 0.))
+        if w0 == -1. and wa == 0.:
+            return
+        if int(self._rph_setting('RPHwDE', 0)) == 0:
+            warnings.warn(
+                "HEFTCAMBEngine: w0_fld={}, wa_fld={} but RPHwDE=0, so EFTCAMB will use a "
+                "cosmological constant background. CAMB's own dark energy is bypassed when "
+                "EFTflag != 0, so the equation of state would be silently ignored. Set "
+                "RPHwDE / RPHw0 / RPHwa explicitly, or leave heftcamb_map_w0wa=True.".format(w0, wa)
+            )
+
+    def _map_w0wa_to_rph(self):
+        """Translate (w0_fld, wa_fld) into the EFTCAMB background flags.
+
+        Only applied when the dark energy equation of state is not the
+        cosmological constant and when the user has not set RPHwDE
+        explicitly. EFTCAMB drives its own background from RPHwDE, so
+        without this the cosmoprimo w0/wa would have no effect on the
+        EFTCAMB side.
+        """
+        if not getattr(self, '_heftcamb_map_w0wa', True):
+            return
+        if 'RPHwDE' in self._params or 'RPHwDE' in self._extra_params:
+            return
+
+        w0 = float(self._params.get('w0_fld', -1.))
+        wa = float(self._params.get('wa_fld', 0.))
+        if w0 == -1. and wa == 0.:
+            return
+
+        self._extra_params['RPHwDE'] = 2   # CPL
+        self._extra_params['RPHw0'] = w0
+        self._extra_params['RPHwa'] = wa
+
+    def _prune_rph_params(self):
+        """Drop RPH shape parameters that the active model flags will not read.
+
+        HEFTCAMB's ``camb.set_params`` hands the whole parameter dictionary
+        to EFTCAMB, then marks as used only the keys the Fortran side
+        actually queried (``Ini%ReadValues``). Any key left over is fed to
+        ``setattr(CAMBparams, ...)`` and raises ``CAMBUnknownArgumentError``.
+
+        A parametrized function only reads the parameters of the model it was
+        allocated with, so e.g. ``RPHalphaM_cM`` must not be forwarded unless
+        ``RPHalphaMmodel == 12``.
+        """
+        known, keep = set(), set()
+
+        use_alpham = bool(self._rph_setting('RPHusealphaM', True))
+        active = _RPH_COMMON_BRANCHES + (_RPH_ALPHAM_BRANCHES if use_alpham else _RPH_MASSP_BRANCHES)
+
+        # RPH_M0 is read only on the alpha_M branch.
+        known.add('RPH_M0')
+        if use_alpham:
+            keep.add('RPH_M0')
+
+        for flag_name, func_name in _RPH_ALPHA_BRANCHES:
+            flag = int(self._rph_setting(flag_name, 0))
+            is_active = (flag_name, func_name) in active
+            for candidate_flag, suffixes in _RPH_FLAG_PARAM_SUFFIXES.items():
+                names = {func_name + suffix for suffix in suffixes}
+                known |= names
+                if is_active and candidate_flag == flag:
+                    keep |= names
+
+        wde_flag = int(self._rph_setting('RPHwDE', 0))
+        for candidate_flag, names in _RPH_WDE_FLAG_PARAMS.items():
+            known |= set(names)
+            if candidate_flag == wde_flag:
+                keep |= set(names)
+
+        drop = known - keep
+
+        self._pruned_rph_params = {}
+        for container in (self._params, self._extra_params):
+            for key in list(container):
+                if key in drop:
+                    self._pruned_rph_params[key] = container.pop(key)
+
+        if self._pruned_rph_params and getattr(self, '_heftcamb_debug', False):
+            print(
+                "HEFTCAMBEngine: not forwarding unused RPH shape parameters "
+                + ", ".join(sorted(self._pruned_rph_params)),
+                flush=True,
+            )
+
+    def _annotate_init_error(self, exc):
+        """Add a build hint when initialisation fails with flag 12 requested.
+
+        ``allocate_parametrized_1D_function`` only prints "No model corresponding
+        to flag" when ``feedback_level > 0``; with the default of 0 an unknown
+        model flag surfaces as a bare EFTCAMB initialisation failure. Rather than
+        warning on every run that uses flag 12, the hint is attached here, where
+        something has actually gone wrong.
+        """
+        if not self._hillvalley_requested():
+            return exc
+        message = (
+            "EFTCAMB initialisation failed while RPH model flag {} (hill/valley alpha, "
+            "Brando et al. JCAP 11 (2019) 018 eq. 3.2) was requested. If this HEFTCAMB build "
+            "does not provide flag {}, add "
+            "fortran/eftcamb/04f_parametrizations_1D/04p020_hillvalley_parametrizations_1D.f90 "
+            "with its case({}) entry in 04p1_parametrizations_1D_allocator.f90 and rebuild "
+            "(make eftcamb_dep && make clean && make camb). Setting feedback_level=1 makes "
+            "EFTCAMB report an unknown model flag explicitly. Original error: {!r}".format(
+                HILLVALLEY_FLAG, HILLVALLEY_FLAG, HILLVALLEY_FLAG, exc)
+        )
+        try:
+            return type(exc)(message)
+        except Exception:
+            return RuntimeError(message)
+
+    def _hillvalley_requested(self):
+        """Whether any alpha branch asks for the hill/valley parametrization."""
+        if getattr(self, '_hillvalley_in_kwargs', False):
+            return True
+        for flag_name, _ in _RPH_ALPHA_BRANCHES:
+            try:
+                if int(self._rph_setting(flag_name, 0)) == HILLVALLEY_FLAG:
+                    return True
+            except (TypeError, ValueError):
+                continue
+        return False
 
     def _set_camb(self):
         import camb as heftcamb
@@ -191,6 +578,20 @@ class HEFTCAMBEngine(CambEngine):
             for key in self._wrapper_private_keys:
                 self._params.pop(key, None)
 
+        # _set_camb() is called by CambEngine.__init__ after _params and
+        # _extra_params are set and before base_params is assembled, so this
+        # is the right place to finalise the EFTCAMB parameter set.
+        self._resolve_default_param_conflicts()
+        self._map_w0wa_to_rph()
+        self._check_background_consistency()
+        self._prune_rph_params()
+
+        if getattr(self, '_heftcamb_debug', False):
+            self._debug_effective_params()
+
+    # ------------------------------------------------------------------
+    # Builders
+    # ------------------------------------------------------------------
     @staticmethod
     def _build_rph_eftcamb_params(
         *,
@@ -260,6 +661,112 @@ class HEFTCAMBEngine(CambEngine):
             "EFT_additional_priors": bool(EFT_additional_priors),
         }
 
+    @staticmethod
+    def _build_hillvalley_eftcamb_params(
+        *,
+        cM=-0.05,
+        at=0.5,
+        tau=1.0,
+        no_slip=True,
+        RPH_kinetic0=1.0,
+        w0=None,
+        wa=None,
+        feedback_level=0,
+        EFTCAMB_back_turn_on=1.0e-8,
+        EFTCAMB_turn_on_time=1.0e-8,
+        EFTCAMB_skip_stability=True,
+        EFT_ghost_math_stability=False,
+        EFT_mass_math_stability=False,
+        EFT_ghost_stability=True,
+        EFT_gradient_stability=True,
+        EFT_mass_stability=False,
+        EFT_additional_priors=False,
+    ):
+        """Build the hill/valley alpha_M parameters of eq. (3.2) of
+        Brando, Falciano, Linder & Velten, JCAP 11 (2019) 018.
+
+            alpha_M(a) = cM tanh[(tau/2) ln(a/at)] / cosh^2[(tau/2) ln(a/at)]
+
+        Stability requires cM < 0, and the extremal amplitude is
+        0.385 |cM|, not |cM|.
+
+        With ``no_slip=True`` the braiding is locked to the No Slip Gravity
+        condition alpha_B = -2 alpha_M in the Bellini-Sawicki convention.
+        EFTCAMB stores alpha_B^EFTCAMB = -alpha_B^BS / 2 (see the comment at
+        008p0_Horndeski.f90:1783 and the assignment in 007p2_RPH.f90), so in
+        EFTCAMB's own convention this is alpha_B = +alpha_M: the same
+        functional form with the same three parameters.
+
+        ``w0`` / ``wa`` optionally select a CPL background (RPHwDE = 2).
+        """
+        params = {
+            # Model selection
+            "EFTflag": 2,
+            "AltParEFTmodel": 1,
+
+            # Runtime / stability
+            "EFTCAMB_back_turn_on": float(EFTCAMB_back_turn_on),
+            "EFTCAMB_turn_on_time": float(EFTCAMB_turn_on_time),
+            "EFTCAMB_skip_stability": bool(EFTCAMB_skip_stability),
+            "feedback_level": int(feedback_level),
+
+            # RPH alpha-basis setup.  alpha_M -> 0 in the early universe for
+            # this shape, so integrate the M^2 ODE from the radiation era
+            # starting at M^2 = m_0^2.
+            "RPHintegratefromtoday": False,
+            "RPHusealphaM": True,
+            "RPH_M0": 0.0,
+
+            # alpha_M: hill/valley
+            "RPHalphaMmodel": HILLVALLEY_FLAG,
+            "RPHalphaM_cM": float(cM),
+            "RPHalphaM_at": float(at),
+            "RPHalphaM_tau": float(tau),
+            "RPHalphaMmodel_ODE": 0,
+
+            # alpha_K(a) = cK * Omega_DE(a); irrelevant on sub-horizon scales
+            # but must be non-zero to avoid a singular kinetic term.
+            "RPHkineticitymodel": 0,
+            "RPHkineticitymodel_ODE": 2,
+            "RPHkineticity_ODE0": float(RPH_kinetic0),
+
+            # alpha_T = 0 (GW speed = c)
+            "RPHtensormodel": 0,
+            "RPHtensormodel_ODE": 0,
+
+            # Optional stability flags
+            "EFT_ghost_math_stability": bool(EFT_ghost_math_stability),
+            "EFT_mass_math_stability": bool(EFT_mass_math_stability),
+            "EFT_ghost_stability": bool(EFT_ghost_stability),
+            "EFT_gradient_stability": bool(EFT_gradient_stability),
+            "EFT_mass_stability": bool(EFT_mass_stability),
+            "EFT_additional_priors": bool(EFT_additional_priors),
+        }
+
+        if no_slip:
+            params.update({
+                "RPHbraidingmodel": HILLVALLEY_FLAG,
+                "RPHbraiding_cM": float(cM),
+                "RPHbraiding_at": float(at),
+                "RPHbraiding_tau": float(tau),
+                "RPHbraidingmodel_ODE": 0,
+            })
+        else:
+            params.update({
+                "RPHbraidingmodel": 0,
+                "RPHbraidingmodel_ODE": 2,
+                "RPHbraiding_ODE0": 0.0,
+            })
+
+        if w0 is not None or wa is not None:
+            params.update({
+                "RPHwDE": 2,
+                "RPHw0": float(-1.0 if w0 is None else w0),
+                "RPHwa": float(0.0 if wa is None else wa),
+            })
+
+        return params
+
     def _clear_eftcamb_read_cache(self):
         """Clear EFTCAMB Python-side read_parameters() cache."""
         try:
@@ -267,9 +774,30 @@ class HEFTCAMBEngine(CambEngine):
         except Exception:
             pass
 
+    def _debug_effective_params(self):
+        """Print the EFTCAMB parameters exactly as set_params will see them.
+
+        Reproduces ``CambEngine``'s ``all_params = self._extra_params | base_params``
+        priority. This is the dump to trust: the kwargs dump printed before
+        ``super().__init__()`` shows only the engine defaults, not the values
+        carried on the ``Cosmology`` itself.
+        """
+        print("\n" + "=" * 80, flush=True)
+        print("DEBUG HEFTCAMBEngine effective parameters passed to set_params", flush=True)
+        print("=" * 80, flush=True)
+        merged = {**self._extra_params, **self._params}
+        keys = [key for key in merged
+                if key.startswith('RPH') or key in ('EFTflag', 'AltParEFTmodel', 'dark_energy_model')]
+        for key in sorted(keys):
+            print(f"  {key}: {merged[key]}", flush=True)
+        if self._pruned_rph_params:
+            print("  (pruned, not forwarded):", sorted(self._pruned_rph_params), flush=True)
+
     def _debug_kwargs_before_super(self, kwargs):
         print("\n" + "=" * 80, flush=True)
         print("DEBUG HEFTCAMBEngine kwargs before CambEngine", flush=True)
+        print("(engine defaults + extra_params only; values set on the Cosmology "
+              "itself appear later, in the effective-parameter dump)", flush=True)
         print("=" * 80, flush=True)
 
         keys = [
@@ -278,12 +806,22 @@ class HEFTCAMBEngine(CambEngine):
             "AltParEFTmodel",
             "RPHintegratefromtoday",
             "RPHusealphaM",
+            "RPH_M0",
+            "RPHwDE",
+            "RPHw0",
+            "RPHwa",
             "RPHalphaMmodel",
             "RPHalphaMmodel_ODE",
             "RPHalphaM_ODE0",
+            "RPHalphaM_cM",
+            "RPHalphaM_at",
+            "RPHalphaM_tau",
             "RPHbraidingmodel",
             "RPHbraidingmodel_ODE",
             "RPHbraiding_ODE0",
+            "RPHbraiding_cM",
+            "RPHbraiding_at",
+            "RPHbraiding_tau",
             "RPHkineticitymodel",
             "RPHkineticitymodel_ODE",
             "RPHkineticity_ODE0",
@@ -305,6 +843,9 @@ class HEFTCAMBEngine(CambEngine):
         print(f"DEBUG {label}", flush=True)
         print("=" * 80, flush=True)
 
+        if self._pruned_rph_params:
+            print("  pruned (not forwarded):", sorted(self._pruned_rph_params), flush=True)
+
         if not hasattr(self, "_camb_params"):
             print("No self._camb_params available.", flush=True)
             return
@@ -323,12 +864,22 @@ class HEFTCAMBEngine(CambEngine):
                 "AltParEFTmodel",
                 "RPHintegratefromtoday",
                 "RPHusealphaM",
+                "RPH_M0",
+                "RPHwDE",
+                "RPHw0",
+                "RPHwa",
                 "RPHalphaMmodel",
                 "RPHalphaMmodel_ODE",
                 "RPHalphaM_ODE0",
+                "RPHalphaM_cM",
+                "RPHalphaM_at",
+                "RPHalphaM_tau",
                 "RPHbraidingmodel",
                 "RPHbraidingmodel_ODE",
                 "RPHbraiding_ODE0",
+                "RPHbraiding_cM",
+                "RPHbraiding_at",
+                "RPHbraiding_tau",
                 "RPHkineticitymodel",
                 "RPHkineticitymodel_ODE",
                 "RPHkineticity_ODE0",

--- a/cosmoprimo/heftcamb.py
+++ b/cosmoprimo/heftcamb.py
@@ -79,6 +79,66 @@ _RPH_ALPHA_BRANCHES = _RPH_COMMON_BRANCHES + _RPH_ALPHAM_BRANCHES + _RPH_MASSP_B
 # and registered as case(12) in 04p1_parametrizations_1D_allocator.f90.
 HILLVALLEY_FLAG = 12
 
+# ----------------------------------------------------------------------
+# Braiding convention.
+#
+# EFTCAMB and hi_class / mochi-class normalise the braiding differently:
+#
+#     alpha_B(EFTCAMB) = -0.5 * alpha_B(hi_class)
+#
+# so the same physical model needs different numbers in the two codes. The
+# other alpha functions (alpha_K, alpha_M, alpha_T) and M_*^2 share a
+# convention. Verified against the 'mochiclass' engine over a 1000-point
+# Latin-hypercube scan of (alpha_M0, alpha_B0, w0, wa): with this factor the
+# two codes agree on every stability verdict, and on the linear matter power
+# spectrum to the same 0.16% that plain 'class' and 'camb' agree to in LCDM.
+#
+# The c_K / c_B / c_M / c_T / M2_ini arguments of HEFTCAMBEngine are in the
+# *hi_class* convention (they are mochi-class's parameters_smg entries), so
+# that the 'mochiclass' and 'heftcamb' engines take identical arguments; the
+# conversion happens in _apply_alpha_basis().
+# ----------------------------------------------------------------------
+BRAIDING_EFTCAMB_OVER_HICLASS = -0.5
+
+
+def _designer_normalisation_is_reliable(camb):
+    """Whether this HEFTCAMB build normalises the RPH designer background correctly.
+
+    ``RPHintegratefromtoday = False`` makes 007p2_RPH.f90 normalise rho_DE with
+    a *single* DLSODA call across the whole grid, capped at ``IWORK(6) = 100``
+    steps. For any w(a) != -1 that cap is reached; the code only warns
+    (``istate = -1`` -> ``istate = 1``) and then uses the unconverged value, so
+    rho_DE(a=1) != rho_DE,0 and the run silently ends up at the wrong H0
+    (measured: 44.8 to 5.5e13 km/s/Mpc where 67.36 was requested, giving a
+    linear power spectrum wrong by seven orders of magnitude).
+
+    Probing is cheap (one background-only run, ~15 ms) and the answer is a
+    property of the build, so it is cached. A patched build returns True and
+    nothing further is said; an unpatched one triggers the warning in
+    :meth:`HEFTCAMBEngine._check_designer_normalisation`.
+    """
+    global _DESIGNER_NORMALISATION_OK
+    if _DESIGNER_NORMALISATION_OK is None:
+        h0 = 67.36
+        try:
+            pars = camb.set_params(
+                H0=h0, ombh2=0.02237, omch2=0.12, mnu=0., EFTflag=2, AltParEFTmodel=1,
+                EFTCAMB_skip_stability=True, feedback_level=0,
+                RPHintegratefromtoday=False, RPHusealphaM=True, RPH_M0=0.,
+                RPHalphaMmodel=0, RPHalphaMmodel_ODE=2, RPHalphaM_ODE0=0.,
+                RPHkineticitymodel=0, RPHkineticitymodel_ODE=2, RPHkineticity_ODE0=1.,
+                RPHbraidingmodel=0, RPHbraidingmodel_ODE=2, RPHbraiding_ODE0=0.,
+                RPHtensormodel=0, RPHtensormodel_ODE=2, RPHtensor_ODE0=0.,
+                RPHwDE=2, RPHw0=-0.9, RPHwa=-0.5)
+            results = camb.get_background(pars, no_thermo=True)
+            _DESIGNER_NORMALISATION_OK = abs(float(results.hubble_parameter(0.)) / h0 - 1.) < 1e-6
+        except Exception:  # noqa: BLE001 - a probe must never break the engine
+            _DESIGNER_NORMALISATION_OK = True
+    return _DESIGNER_NORMALISATION_OK
+
+
+_DESIGNER_NORMALISATION_OK = None
+
 
 class Background(CambBackground):
     """CAMB background section, with the GR-only growth solver disabled.
@@ -157,6 +217,22 @@ class HEFTCAMBEngine(CambEngine):
 
     Shape parameters that the selected model flag would not read are
     stripped before reaching camb.set_params(...); see _prune_rph_params.
+
+    For the default shape the alpha functions can be given in the hi_class /
+    mochi-class convention as ``c_K, c_B, c_M, c_T, M2_ini`` -- exactly
+    mochi-class's ``parameters_smg`` -- so that the same call describes the same
+    model on either engine::
+
+        common = dict(c_K=1., c_B=1., c_M=1., c_T=0., M2_ini=1.,
+                      w0_fld=-0.9, wa_fld=-0.5)
+        AbacusSummit(0, engine='heftcamb', **common)
+        AbacusSummit(0, engine='mochiclass', Omega_Lambda=0., Omega_fld=0.,
+                     Omega_smg=-1., gravity_model='propto_omega',
+                     parameters_smg='1., 1., 1., 0., 1.',
+                     expansion_model='wowa', expansion_smg='0.685, -0.9, -0.5')
+
+    The braiding is converted by ``BRAIDING_EFTCAMB_OVER_HICLASS``; the raw
+    ``RPHbraiding_ODE0`` etc. remain available for EFTCAMB-convention input.
     """
 
     name = "heftcamb"
@@ -207,8 +283,31 @@ class HEFTCAMBEngine(CambEngine):
 
         # EFTCAMB turn-on / stability settings
         EFTCAMB_back_turn_on=1.0e-8,
-        EFTCAMB_turn_on_time=1.0e-8,
-        EFTCAMB_skip_stability=True,
+
+        # CAMB's own default. Earlier values make CAMB abort with "EFTCAMB
+        # starts before thermo tauminn, EFT_pert_turn_on, EFTturnOnTime" over a
+        # large part of the (alpha_M0, alpha_B0, w0, wa) box.
+        EFTCAMB_turn_on_time=1.0e-2,
+
+        # Run EFTCAMB's stability module. With it skipped the engine reports
+        # every model as computable, so it can neither agree nor disagree with
+        # the 'mochiclass' engine on stability.
+        EFTCAMB_skip_stability=False,
+
+        # Earliest scale factor at which stability is tested. EFTCAMB's own
+        # default (1e-10) precedes the designer background grid
+        # (model_background_a_ini = 1e-8) and EFTStabilityComputation does not
+        # clamp to EFTCAMB_back_turn_on, so the sampler would extrapolate the
+        # interpolation tables.
+        #
+        # On a build carrying the EFTCAMB_stability_threshold patch (see
+        # Stability/PACKAGE_CHANGES.md in the DESI-DR2-CPE project) this whole
+        # window is usable and the verdicts match mochi-class. On an unpatched
+        # build, EFT_kinetic / EFT_gradient are compared against zero with no
+        # tolerance even where they have cancelled down to the round-off floor,
+        # so early times return the sign of the noise; raise this to ~0.1 there.
+        EFTCAMB_stability_time=1.0e-8,
+
         feedback_level=0,
 
         # Optional stability flags
@@ -252,10 +351,24 @@ class HEFTCAMBEngine(CambEngine):
         "heftcamb_debug",
         "heftcamb_map_w0wa",
         "heftcamb_gr_growth",
+        "heftcamb_check_designer",
         "RPH_massP0",
         "RPH_braiding0",
         "RPH_kinetic0",
+        "c_K",
+        "c_B",
+        "c_M",
+        "c_T",
+        "M2_ini",
     ]
+
+    # hi_class / mochi-class alpha-basis arguments -> the RPH flags they set.
+    # c_B is handled separately because of BRAIDING_EFTCAMB_OVER_HICLASS.
+    _ALPHA_BASIS_KEYS = {
+        "c_K": "RPHkineticity_ODE0",
+        "c_M": "RPHalphaM_ODE0",
+        "c_T": "RPHtensor_ODE0",
+    }
 
     def __init__(self, *args, **kwargs):
         # ------------------------------------------------------------
@@ -275,11 +388,23 @@ class HEFTCAMBEngine(CambEngine):
         # which does not describe the modified gravity model (see Background).
         heftcamb_gr_growth = kwargs.pop("heftcamb_gr_growth", False)
 
+        # Whether to probe the build for the RPH designer normalisation bug.
+        heftcamb_check_designer = kwargs.pop("heftcamb_check_designer", True)
+
         # Stash on self: _set_camb() runs inside super().__init__().
         self._heftcamb_debug = bool(heftcamb_debug)
         self._heftcamb_map_w0wa = bool(heftcamb_map_w0wa)
         self._heftcamb_gr_growth = bool(heftcamb_gr_growth)
+        self._heftcamb_check_designer = bool(heftcamb_check_designer)
         self._pruned_rph_params = {}
+
+        # The alpha basis given as extra_params has to be stashed here: the
+        # wrapper-private keys are dropped from kwargs further down, before
+        # super().__init__() (and hence _set_camb()) ever sees them.
+        self._alpha_basis_kwargs = {
+            name: kwargs[name]
+            for name in list(self._ALPHA_BASIS_KEYS) + ["c_B", "M2_ini"]
+            if kwargs.get(name, None) is not None}
 
         # Convenience aliases.
         # Use None defaults so these aliases do not accidentally overwrite
@@ -287,6 +412,11 @@ class HEFTCAMBEngine(CambEngine):
         RPH_massP0 = kwargs.pop("RPH_massP0", None)
         RPH_braiding0 = kwargs.pop("RPH_braiding0", None)
         RPH_kinetic0 = kwargs.pop("RPH_kinetic0", None)
+
+        # The hi_class / mochi-class alpha basis (c_K, c_B, c_M, c_T, M2_ini) is
+        # not handled here: it can also arrive as a top-level Cosmology
+        # parameter, which lands in self._params rather than in these kwargs.
+        # Both paths are picked up by _apply_alpha_basis() from _set_camb().
 
         # ------------------------------------------------------------
         # Build parameter dictionary to push through CambEngine.
@@ -343,8 +473,45 @@ class HEFTCAMBEngine(CambEngine):
         # read_parameters() is cached Python-side; clear before debug.
         self._clear_eftcamb_read_cache()
 
+        self._check_designer_normalisation()
+
         if heftcamb_debug:
             self._debug_eftcamb_parameters("after CambEngine")
+
+    def _check_designer_normalisation(self):
+        """Warn when this build would silently mis-normalise the RPH background.
+
+        Only fires on an unpatched HEFTCAMB (probed once per process, see
+        :func:`_designer_normalisation_is_reliable`) and only for the
+        configuration that triggers the bug: a non-trivial w(a) integrated from
+        early times. Silence therefore means the build is fine, not that the
+        check was skipped.
+        """
+        if not getattr(self, '_heftcamb_check_designer', True):
+            return
+        if not self._eftcamb_drives_background():
+            return
+        try:
+            if bool(self._rph_setting('RPHintegratefromtoday', False)):
+                return
+            w0 = float(self._rph_setting('RPHw0', -1.))
+            wa = float(self._rph_setting('RPHwa', 0.))
+        except (TypeError, ValueError):
+            return
+        if w0 == -1. and wa == 0.:
+            return
+        if _designer_normalisation_is_reliable(self.camb):
+            return
+        warnings.warn(
+            "HEFTCAMBEngine: this HEFTCAMB build mis-normalises the RPH designer background "
+            "for w(a) != -1 (w0={}, wa={}). fortran/eftcamb/07f_designer_models/007p2_RPH.f90 "
+            "normalises rho_DE with one DLSODA call capped at IWORK(6) = 100 steps, always "
+            "exhausts it, warns, and then uses the unconverged value, so the run ends up at "
+            "the wrong H0 and the linear power spectrum can be wrong by orders of magnitude. "
+            "Apply the 007p2_RPH.f90 patch and rebuild, or pass RPHintegratefromtoday=True "
+            "(which imposes 1 + RPH_M0 = M_*^2 today rather than at early times, so M2_ini "
+            "must be recalibrated). Pass heftcamb_check_designer=False to silence this."
+            .format(w0, wa))
 
     # ------------------------------------------------------------------
     # RPH parameter bookkeeping
@@ -360,6 +527,52 @@ class HEFTCAMBEngine(CambEngine):
             if name in container:
                 return container[name]
         return self._default_calculation_parameters.get(name, default)
+
+    def _collect_alpha_basis(self):
+        """Pick up c_K / c_B / c_M / c_T / M2_ini from wherever they arrived.
+
+        ``self._params`` (a top-level ``Cosmology`` parameter) wins over
+        ``self._extra_params``, matching :meth:`_rph_setting`.
+        """
+        names = list(self._ALPHA_BASIS_KEYS) + ["c_B", "M2_ini"]
+        basis = dict(getattr(self, '_alpha_basis_kwargs', {}))
+        for name in names:
+            for container in (getattr(self, '_extra_params', {}), getattr(self, '_params', {})):
+                value = container.get(name, None)
+                if value is not None:
+                    basis[name] = value
+        return basis
+
+    def _apply_alpha_basis(self, basis):
+        """Translate the hi_class alpha basis into the RPH flags.
+
+        ``alpha_i(a) = c_i * Omega_DE(a)`` in both codes, so c_K, c_M and c_T
+        carry straight over to RPHkineticity_ODE0 / RPHalphaM_ODE0 /
+        RPHtensor_ODE0; only the braiding needs
+        :data:`BRAIDING_EFTCAMB_OVER_HICLASS`. ``M2_ini`` is mochi-class's
+        ``parameters_smg`` entry 5, the effective Planck mass at the start of
+        the integration, which is what ``1 + RPH_M0`` sets while
+        ``RPHintegratefromtoday`` is False.
+
+        The converted flags are written into ``self._extra_params`` rather than
+        ``self._params``: ``_set_camb`` strips the wrapper-private c_K/c_B/...
+        keys from the very dict the ``Cosmology`` holds, so a later
+        ``Cosmology.clone()`` (which ``AbacusSummit`` performs internally) would
+        otherwise rebuild the engine with the alpha basis already gone. Storing
+        the RPH flags instead makes the translation survive cloning.
+        Precedence is unchanged: a raw RPH flag given as a top-level parameter
+        lands in ``self._params`` and still wins.
+        """
+        if not basis:
+            return
+        target = self._extra_params if hasattr(self, '_extra_params') else self._params
+        for name, flag in self._ALPHA_BASIS_KEYS.items():
+            if name in basis:
+                target[flag] = float(basis[name])
+        if 'c_B' in basis:
+            target['RPHbraiding_ODE0'] = BRAIDING_EFTCAMB_OVER_HICLASS * float(basis['c_B'])
+        if 'M2_ini' in basis:
+            target['RPH_M0'] = float(basis['M2_ini']) - 1.
 
     def _resolve_default_param_conflicts(self):
         """Let explicit ``extra_params`` win over untouched class defaults.
@@ -568,6 +781,11 @@ class HEFTCAMBEngine(CambEngine):
 
         self.camb = heftcamb
 
+        # Read the hi_class-convention alpha basis before the loops below drop
+        # it: c_K/c_B/c_M/c_T/M2_ini are wrapper-private, and they may have
+        # arrived either as extra_params or as top-level Cosmology parameters.
+        alpha_basis = self._collect_alpha_basis()
+
         # Clean only wrapper-private keys.
         # Do NOT remove real EFTCAMB/RPH parameters.
         if hasattr(self, "_extra_params"):
@@ -581,6 +799,10 @@ class HEFTCAMBEngine(CambEngine):
         # _set_camb() is called by CambEngine.__init__ after _params and
         # _extra_params are set and before base_params is assembled, so this
         # is the right place to finalise the EFTCAMB parameter set.
+        # Before _resolve_default_param_conflicts(), which is what lets the
+        # values written into _extra_params win over the untouched class
+        # defaults sitting in _params.
+        self._apply_alpha_basis(alpha_basis)
         self._resolve_default_param_conflicts()
         self._map_w0wa_to_rph()
         self._check_background_consistency()

--- a/cosmoprimo/heftcamb.py
+++ b/cosmoprimo/heftcamb.py
@@ -101,6 +101,71 @@ HILLVALLEY_FLAG = 12
 BRAIDING_EFTCAMB_OVER_HICLASS = -0.5
 
 
+# ----------------------------------------------------------------------
+# Closed forms of the hill/valley parametrization, arXiv:1904.12903.
+#
+# Same expressions as mochi-class' gravity_models_hill_valley_smg()
+# (gravity_smg/gravity_models_smg.c), evaluated through x = exp(-|u|) in
+# [0, 1] rather than through y = (a/a_t)^tau, since y overflows for large
+# tau while x underflows to zero -- which is the correct general
+# relativity limit (alpha_M -> 0, M_*^2 -> const) at the very small scale
+# factors where the background integration starts.
+# ----------------------------------------------------------------------
+
+def _hill_valley_sech2_tanh(a, tau, a_t):
+    """``sech^2(u)`` and ``tanh(u)`` for ``u = (tau / 2) ln(a / a_t)``, overflow-free."""
+    a = np.asarray(a, dtype='f8')
+    u = 0.5 * tau * np.log(a / a_t)
+    x2 = np.exp(-2. * np.abs(u))          # = exp(-2|u|), in [0, 1]
+    opx2 = 1. + x2
+    sech2 = 4. * x2 / opx2**2
+    tanh = np.sign(u) * (1. - x2) / opx2
+    return sech2, tanh
+
+
+def hill_valley_alpha_M(a, c_M, tau, a_t):
+    r"""
+    Hill/valley running of the Planck mass, eq. (6) of `arXiv:1904.12903
+    <https://arxiv.org/abs/1904.12903>`_:
+
+    .. math:: \alpha_M(a) = c_M \frac{\tanh u}{\cosh^2 u}, \qquad u = \frac{\tau}{2} \ln \frac{a}{a_t}.
+
+    The extrema are :math:`\pm 0.385 c_M`, at :math:`a = a_t (2 \pm \sqrt{3})^{1/\tau}`, so the
+    amplitude of :math:`\alpha_M` is *not* :math:`|c_M|`.
+    """
+    sech2, tanh = _hill_valley_sech2_tanh(a, tau, a_t)
+    return c_M * tanh * sech2
+
+
+def hill_valley_M2(a, c_M, tau, a_t, M2_ini=1.):
+    r"""
+    Effective Planck mass squared of the hill/valley model, the exact integral of
+    :func:`hill_valley_alpha_M`, eq. (10) of `arXiv:1904.12903
+    <https://arxiv.org/abs/1904.12903>`_:
+
+    .. math:: M_\ast^2(a) = M_{\ast,\mathrm{ini}}^2 \exp\left[-\frac{c_M}{\tau} \mathrm{sech}^2 u\right],
+
+    normalised so that :math:`M_\ast^2 \to M_{\ast,\mathrm{ini}}^2` as :math:`a \to 0`, which is
+    the normalisation mochi-class uses and the one ``1 + RPH_M0`` sets on the HEFTCAMB side while
+    ``RPHintegratefromtoday`` is False.
+    """
+    sech2, _ = _hill_valley_sech2_tanh(a, tau, a_t)
+    return M2_ini * np.exp(-c_M / tau * sech2)
+
+
+# How much of the Planck-mass running may already have happened by the time EFTCAMB switches the
+# EFT sector on in the perturbations, before :meth:`HEFTCAMBEngine._check_turn_on_time` complains.
+# The induced error on sigma8 is roughly this offset times ~1.2 (measured, see that method), so
+# 1e-4 keeps it an order of magnitude below the ~0.02% CLASS-vs-CAMB floor.
+TURN_ON_M2_OFFSET_TOLERANCE = 1.e-4
+
+# Empirical lower end of the usable EFTCAMB_turn_on_time range: at 1e-5 the EFT turn-on precedes
+# the start of the thermodynamics grid and the run returns a wrong power spectrum *without*
+# raising (measured: +2.2% on sigma8_cb where +0.025% was correct). This is a property of the
+# build and of the thermodynamics sampling rather than of the model, so it is only a warning.
+TURN_ON_TIME_MIN = 1.e-4
+
+
 def _designer_normalisation_is_reliable(camb):
     """Whether this HEFTCAMB build normalises the RPH designer background correctly.
 
@@ -369,8 +434,40 @@ class HEFTCAMBEngine(CambEngine):
                      parameters_smg='1., 1., 1., 0., 1.',
                      expansion_model='wowa', expansion_smg='0.685, -0.9, -0.5')
 
-    The braiding is converted by ``BRAIDING_EFTCAMB_OVER_HICLASS``; the raw
-    ``RPHbraiding_ODE0`` etc. remain available for EFTCAMB-convention input.
+    More generally, mochi-class's own ``gravity_model`` / ``parameters_smg`` pair is
+    accepted directly, for the models listed in ``_PARAMETERS_SMG_NAMES``
+    (``'propto_omega'``, and ``'hill_valley'`` aka ``'no_slip_gravity'``). Then the
+    *identical* model arguments go to either engine::
+
+        common = dict(gravity_model='hill_valley',
+                      # alpha_K, c_M, tau, a_t, r, M*^2_ini
+                      parameters_smg=[1e-4, -0.05, 1., 0.5, 2., 1.],
+                      w0_fld=-0.9, wa_fld=0.36)
+        DESI(engine='heftcamb', **common)
+        DESI(engine='mochiclass', Omega_Lambda=0, Omega_fld=0, Omega_smg=-1,
+             expansion_model='wowa', expansion_smg=[0.68, -0.9, 0.36], **common)
+
+    ``parameters_smg`` may be a sequence or mochi-class's comma-separated string.
+    The keyword form ``hill_valley=dict(alpha_K=..., c_M=..., tau=..., a_t=..., r=...,
+    M2_ini=...)`` is equivalent and does not depend on entry order.
+
+    **Conventions are the engine's job, not the caller's.** The braiding differs by
+    ``BRAIDING_EFTCAMB_OVER_HICLASS = -0.5`` between the two codes, and every
+    hi_class-convention entry point above applies it internally
+    (:meth:`_braiding_hiclass_to_eftcamb`) -- for ``propto_omega``'s ``c_B`` and for
+    hill/valley's ``alpha_B = -r alpha_M`` alike. Nothing outside this module should
+    multiply a braiding by -1/2. Reading it back out, :meth:`Background._eft_of_de_at_eta`
+    undoes the factor, so ``alpha_B`` is reported in the hi_class convention too.
+    The raw ``RPHbraiding_ODE0`` / ``RPHbraiding_cM`` etc. remain available for input
+    that is already in the EFTCAMB convention.
+
+    One numerical switch does *not* have a safe default for every model:
+    ``EFTCAMB_turn_on_time``, the scale factor at which the EFT sector enters the
+    perturbation equations. CAMB's default of 1e-2 is far too late for the
+    hill/valley shape and costs ~1% on the linear power spectrum;
+    :meth:`_check_turn_on_time` warns about that, and about the silently wrong
+    results returned when it is pushed too early. Pass
+    ``heftcamb_check_turn_on=False`` to silence it.
     """
 
     name = "heftcamb"
@@ -490,6 +587,7 @@ class HEFTCAMBEngine(CambEngine):
         "heftcamb_map_w0wa",
         "heftcamb_gr_growth",
         "heftcamb_check_designer",
+        "heftcamb_check_turn_on",
         "RPH_massP0",
         "RPH_braiding0",
         "RPH_kinetic0",
@@ -498,6 +596,24 @@ class HEFTCAMBEngine(CambEngine):
         "c_M",
         "c_T",
         "M2_ini",
+        "gravity_model",
+        "parameters_smg",
+        "hill_valley",
+    ]
+
+    # Wrapper-only *options* (as opposed to model description). These are popped from kwargs in
+    # __init__ and stashed on self, which on its own does not survive Cosmology.clone(): clone
+    # rebuilds the engine from the previous engine's _extra_params, and _set_camb() has by then
+    # stripped every wrapper-private key from it. Since AbacusSummit / DESI clone internally, an
+    # option passed by the user would silently revert to its default. They are therefore put back
+    # into _extra_params once CAMB has been configured; see the end of __init__.
+    _wrapper_option_keys = [
+        "eftcamb_print_header",
+        "heftcamb_debug",
+        "heftcamb_map_w0wa",
+        "heftcamb_gr_growth",
+        "heftcamb_check_designer",
+        "heftcamb_check_turn_on",
     ]
 
     # hi_class / mochi-class alpha-basis arguments -> the RPH flags they set.
@@ -508,10 +624,26 @@ class HEFTCAMBEngine(CambEngine):
         "c_T": "RPHtensor_ODE0",
     }
 
+    # mochi-class ``gravity_model`` values this engine knows how to translate, mapped to the
+    # names of the ``parameters_smg`` entries they take, in mochi-class' order. See
+    # gravity_smg/gravity_models_smg.c.
+    _PARAMETERS_SMG_NAMES = {
+        "propto_omega": ("c_K", "c_B", "c_M", "c_T", "M2_ini"),
+        "hill_valley": ("alpha_K", "c_M", "tau", "a_t", "r", "M2_ini"),
+    }
+
+    # mochi-class accepts 'no_slip_gravity' as an alias of 'hill_valley'.
+    _GRAVITY_MODEL_ALIASES = {"no_slip_gravity": "hill_valley"}
+
     def __init__(self, *args, **kwargs):
         # ------------------------------------------------------------
         # Wrapper-only options
         # ------------------------------------------------------------
+        # Remember which ones the caller actually gave, so they can be restored into
+        # _extra_params below and survive a later clone(); see _wrapper_option_keys.
+        wrapper_options = {name: kwargs[name] for name in self._wrapper_option_keys
+                           if name in kwargs}
+
         eftcamb_params = kwargs.pop("eftcamb_params", None)
         eftcamb_print_header = kwargs.pop("eftcamb_print_header", False)
         heftcamb_debug = kwargs.pop("heftcamb_debug", eftcamb_print_header)
@@ -529,11 +661,15 @@ class HEFTCAMBEngine(CambEngine):
         # Whether to probe the build for the RPH designer normalisation bug.
         heftcamb_check_designer = kwargs.pop("heftcamb_check_designer", True)
 
+        # Whether to check EFTCAMB_turn_on_time against the model (see _check_turn_on_time).
+        heftcamb_check_turn_on = kwargs.pop("heftcamb_check_turn_on", True)
+
         # Stash on self: _set_camb() runs inside super().__init__().
         self._heftcamb_debug = bool(heftcamb_debug)
         self._heftcamb_map_w0wa = bool(heftcamb_map_w0wa)
         self._heftcamb_gr_growth = bool(heftcamb_gr_growth)
         self._heftcamb_check_designer = bool(heftcamb_check_designer)
+        self._heftcamb_check_turn_on = bool(heftcamb_check_turn_on)
         self._pruned_rph_params = {}
 
         # The alpha basis given as extra_params has to be stashed here: the
@@ -542,6 +678,14 @@ class HEFTCAMBEngine(CambEngine):
         self._alpha_basis_kwargs = {
             name: kwargs[name]
             for name in list(self._ALPHA_BASIS_KEYS) + ["c_B", "M2_ini"]
+            if kwargs.get(name, None) is not None}
+
+        # Same for the mochi-class-style (gravity_model, parameters_smg) entry point, which lets
+        # the very same arguments describe the same model on either engine; every convention
+        # factor (the braiding in particular) is applied by _apply_gravity_model().
+        self._gravity_model_kwargs = {
+            name: kwargs[name]
+            for name in ("gravity_model", "parameters_smg", "hill_valley")
             if kwargs.get(name, None) is not None}
 
         # Convenience aliases.
@@ -591,6 +735,10 @@ class HEFTCAMBEngine(CambEngine):
         # Remember whether flag 12 was asked for, so that a failure can be
         # attributed to a HEFTCAMB build without the hill/valley parametrization.
         self._hillvalley_in_kwargs = False
+        gravity_model = self._gravity_model_kwargs.get("gravity_model", None)
+        if "hill_valley" in self._gravity_model_kwargs or gravity_model in (
+                "hill_valley", "no_slip_gravity"):
+            self._hillvalley_in_kwargs = True
         for flag_name, _ in _RPH_ALPHA_BRANCHES:
             try:
                 if int(kwargs.get(flag_name, 0)) == HILLVALLEY_FLAG:
@@ -607,6 +755,12 @@ class HEFTCAMBEngine(CambEngine):
             super().__init__(*args, **kwargs)
         except Exception as exc:
             raise self._annotate_init_error(exc) from exc
+
+        # CAMB has been configured by now (CambEngine.__init__ ran _set_camb() and then built
+        # its parameter dictionary), so the wrapper-only options can go back into _extra_params
+        # without reaching camb.set_params. This is what lets them survive Cosmology.clone().
+        if wrapper_options and hasattr(self, "_extra_params"):
+            self._extra_params.update(wrapper_options)
 
         # read_parameters() is cached Python-side; clear before debug.
         self._clear_eftcamb_read_cache()
@@ -708,9 +862,150 @@ class HEFTCAMBEngine(CambEngine):
             if name in basis:
                 target[flag] = float(basis[name])
         if 'c_B' in basis:
-            target['RPHbraiding_ODE0'] = BRAIDING_EFTCAMB_OVER_HICLASS * float(basis['c_B'])
+            target['RPHbraiding_ODE0'] = self._braiding_hiclass_to_eftcamb(basis['c_B'])
         if 'M2_ini' in basis:
             target['RPH_M0'] = float(basis['M2_ini']) - 1.
+
+    @staticmethod
+    def _braiding_hiclass_to_eftcamb(alpha_B):
+        r"""Convert a braiding amplitude from the hi_class / mochi-class convention to EFTCAMB's.
+
+        :math:`\alpha_B^{\rm EFTCAMB} = -\tfrac{1}{2} \alpha_B^{\rm hi\_class}`
+        (:data:`BRAIDING_EFTCAMB_OVER_HICLASS`). This is the single place the factor is applied
+        on input, so that no caller outside this module has to know about it; the inverse is
+        applied on output in :meth:`Background._eft_of_de_at_eta`.
+        """
+        return BRAIDING_EFTCAMB_OVER_HICLASS * float(alpha_B)
+
+    def _collect_gravity_model(self):
+        """Pick up ``gravity_model`` / ``parameters_smg`` / ``hill_valley`` from wherever they came.
+
+        These may arrive as ``extra_params`` (i.e. keyword arguments of this engine) or as
+        top-level :class:`~cosmoprimo.cosmology.Cosmology` parameters, exactly like the
+        ``c_K``/``c_B``/... alpha basis; see :meth:`_collect_alpha_basis`.
+        """
+        toret = dict(getattr(self, '_gravity_model_kwargs', {}))
+        for name in ('gravity_model', 'parameters_smg', 'hill_valley'):
+            for container in (getattr(self, '_extra_params', {}), getattr(self, '_params', {})):
+                value = container.get(name, None)
+                if value is not None:
+                    toret[name] = value
+        return toret
+
+    @classmethod
+    def _parse_parameters_smg(cls, gravity_model, parameters_smg):
+        """Turn mochi-class' ``(gravity_model, parameters_smg)`` into a named dict.
+
+        ``parameters_smg`` is accepted either as a sequence or as the comma-separated string
+        mochi-class itself takes, so that the very same arguments can be handed to either engine.
+        """
+        model = cls._GRAVITY_MODEL_ALIASES.get(gravity_model, gravity_model)
+        if model not in cls._PARAMETERS_SMG_NAMES:
+            raise CosmologyInputError(
+                "gravity_model = {!r} is not one the 'heftcamb' engine can translate; "
+                "it knows {}. Set the RPH flags directly for anything else.".format(
+                    gravity_model, sorted(cls._PARAMETERS_SMG_NAMES) + sorted(cls._GRAVITY_MODEL_ALIASES)))
+        names = cls._PARAMETERS_SMG_NAMES[model]
+        if isinstance(parameters_smg, str):
+            values = [item for item in parameters_smg.replace(',', ' ').split() if item]
+        else:
+            values = list(np.atleast_1d(parameters_smg).ravel())
+        if len(values) != len(names):
+            raise CosmologyInputError(
+                "gravity_model = {!r} takes {:d} parameters_smg entries ({}), got {:d}".format(
+                    gravity_model, len(names), ', '.join(names), len(values)))
+        return model, {name: float(value) for name, value in zip(names, values)}
+
+    def _apply_gravity_model(self, spec):
+        """Translate a mochi-class gravity model into the RPH flags, conventions included.
+
+        This is what lets the same physical model be written the same way on both engines::
+
+            common = dict(gravity_model='hill_valley',
+                          parameters_smg=[1e-4, -0.05, 1., 0.5, 2., 1.],
+                          w0_fld=-0.9, wa_fld=0.36)
+            DESI(engine='heftcamb', **common)
+            DESI(engine='mochiclass', Omega_Lambda=0, Omega_fld=0, Omega_smg=-1,
+                 expansion_model='wowa', expansion_smg=[0.68, -0.9, 0.36], **common)
+
+        In particular the braiding convention factor (:data:`BRAIDING_EFTCAMB_OVER_HICLASS`) is
+        applied here rather than left to the caller. The raw ``RPHbraiding_*`` flags remain
+        available for input that is already in the EFTCAMB convention.
+        """
+        if not spec:
+            return
+        if 'hill_valley' in spec:
+            model, parameters = 'hill_valley', dict(spec['hill_valley'])
+            names = self._PARAMETERS_SMG_NAMES['hill_valley']
+            missing = [name for name in names if name not in parameters]
+            if missing:
+                raise CosmologyInputError(
+                    "hill_valley is missing {}; it takes {}".format(
+                        ', '.join(missing), ', '.join(names)))
+            parameters = {name: float(parameters[name]) for name in names}
+        else:
+            if 'gravity_model' not in spec:
+                raise CosmologyInputError(
+                    "parameters_smg was given without gravity_model, so there is no way to know "
+                    "what the entries mean")
+            if 'parameters_smg' not in spec:
+                raise CosmologyInputError(
+                    "gravity_model = {!r} was given without parameters_smg".format(spec['gravity_model']))
+            model, parameters = self._parse_parameters_smg(spec['gravity_model'], spec['parameters_smg'])
+
+        if model == 'propto_omega':
+            # Same five numbers as the c_K/c_B/c_M/c_T/M2_ini alpha basis.
+            self._apply_alpha_basis(parameters)
+            return
+
+        # --- hill/valley, mochi-class' gravity_model = 'hill_valley' ---------------------------
+        # alpha_M(a) = c_M tanh(u) / cosh^2(u), u = (tau/2) ln(a/a_t), alpha_B = -r alpha_M,
+        # alpha_T = 0, alpha_K constant, M_*^2 -> M2_ini as a -> 0.
+        alpha_K = parameters['alpha_K']
+        c_M, tau, a_t, r, M2_ini = (parameters['c_M'], parameters['tau'], parameters['a_t'],
+                                    parameters['r'], parameters['M2_ini'])
+        # mochi-class raises on these, so raise here too rather than let EFTCAMB produce numbers.
+        if not tau > 0.:
+            raise CosmologyInputError(
+                "hill_valley: tau = {:g}, but tau > 0 is required to recover general relativity at "
+                "early times (see arXiv:1904.12903). Note that (c_M, tau) -> (-c_M, -tau) leaves "
+                "alpha_M unchanged, so use the tau > 0 branch.".format(tau))
+        if not a_t > 0.:
+            raise CosmologyInputError(
+                "hill_valley: a_t = {:g}, but the transition scale factor must be positive.".format(a_t))
+        if not M2_ini > 0.:
+            raise CosmologyInputError(
+                "hill_valley: M_*^2_ini = {:g}, but the early-time Planck mass squared must be "
+                "positive.".format(M2_ini))
+
+        self._hillvalley_in_kwargs = True
+        target = self._extra_params if hasattr(self, '_extra_params') else self._params
+        target.update({
+            # M_*^2 is integrated up from the early universe, where it equals M2_ini.
+            'RPHusealphaM': True,
+            'RPHintegratefromtoday': False,
+            'RPH_M0': M2_ini - 1.,
+            # alpha_M: the hill/valley shape itself.
+            'RPHalphaMmodel': HILLVALLEY_FLAG,
+            'RPHalphaM_cM': c_M,
+            'RPHalphaM_tau': tau,
+            'RPHalphaM_at': a_t,
+            'RPHalphaMmodel_ODE': 0,
+            # alpha_B = -r alpha_M in the hi_class convention. EFTCAMB stores -1/2 of that, so it
+            # is the same shape function again, with the amplitude converted here.
+            'RPHbraidingmodel': HILLVALLEY_FLAG,
+            'RPHbraiding_cM': self._braiding_hiclass_to_eftcamb(-r * c_M),
+            'RPHbraiding_tau': tau,
+            'RPHbraiding_at': a_t,
+            'RPHbraidingmodel_ODE': 0,
+            # alpha_K is a constant in mochi-class' hill_valley, not proportional to Omega_DE.
+            'RPHkineticitymodel': 1,
+            'RPHkineticity0': alpha_K,
+            'RPHkineticitymodel_ODE': 0,
+            # alpha_T = 0 after GW170817.
+            'RPHtensormodel': 0,
+            'RPHtensormodel_ODE': 0,
+        })
 
     def _resolve_default_param_conflicts(self):
         """Let explicit ``extra_params`` win over untouched class defaults.
@@ -810,6 +1105,89 @@ class HEFTCAMBEngine(CambEngine):
         self._extra_params['RPHwDE'] = 2   # CPL
         self._extra_params['RPHw0'] = w0
         self._extra_params['RPHwa'] = wa
+
+    def _check_turn_on_time(self):
+        """Warn when the EFT perturbation turn-on time does not suit the model being run.
+
+        ``EFTCAMB_back_turn_on`` starts the EFT integration of the *background*;
+        ``EFTCAMB_turn_on_time`` is a separate switch deciding when the EFT sector enters the
+        *perturbation* equations. Before it, EFTCAMB evolves plain general relativity, so any
+        Planck-mass running that has already happened by then is never applied to the
+        perturbations -- while hi_class / mochi-class applies it from the start. The two codes
+        then disagree even though they agree on the background, on the alpha functions, and on
+        h1 / h3 / h5.
+
+        For ``alpha_X(a) = c_X Omega_DE(a)`` the alphas are negligible in the early universe and
+        CAMB's default of 1e-2 costs nothing, which is why it is the default. For the hill/valley
+        shape it is not negligible: with (c_M, tau, a_t) = (-0.05, 1, 0.5) the Planck mass has
+        already run to M_*^2 = 1.0039 by a = 1e-2, and on the DESI fiducial cosmology that shows
+        up as a 1.07% error on the linear P_cb(k) against a 0.18% CLASS-vs-CAMB floor, and +0.48%
+        on sigma8_cb. Lowering the turn-on to 1e-4 brings it to +0.025%, i.e. below the floor::
+
+            turn_on   M_*^2 there   sigma8_cb error
+              1e-2      1.003852        +0.476 %
+              1e-3      1.000398        +0.060 %
+              1e-4      1.000040        +0.025 %   <- GR floor is +0.024 %
+              1e-5      1.000004        +2.247 %   <- silently wrong, see below
+
+        The induced error tracks ``M_*^2(a_on) - 1``, the growth suppression that is skipped,
+        which is what is tested here against :data:`TURN_ON_M2_OFFSET_TOLERANCE`.
+
+        Going too early is the other failure mode and is worse, because it does not raise: below
+        about :data:`TURN_ON_TIME_MIN` the EFT turn-on precedes the start of the thermodynamics
+        grid and the run returns a wrong spectrum. Both bounds are checked.
+
+        Only the hill/valley branch is tested, since that is the one whose M_*^2 has a closed
+        form here; nothing is guessed for other parametrizations. Pass
+        ``heftcamb_check_turn_on=False`` to silence.
+        """
+        if not getattr(self, '_heftcamb_check_turn_on', True):
+            return
+        if not self._eftcamb_drives_background():
+            return
+        try:
+            turn_on = float(self._rph_setting('EFTCAMB_turn_on_time', 1.e-2))
+        except (TypeError, ValueError):
+            return
+        if not turn_on > 0.:
+            return
+
+        if turn_on < TURN_ON_TIME_MIN:
+            warnings.warn(
+                "HEFTCAMBEngine: EFTCAMB_turn_on_time = {:g} is below {:g}, where the EFT sector "
+                "is switched on in the perturbations before the thermodynamics grid begins. "
+                "EFTCAMB does not raise on this; it returns a wrong power spectrum (measured: "
+                "+2.2% on sigma8_cb where +0.025% was correct). Scan this switch rather than "
+                "pushing it as early as possible. Pass heftcamb_check_turn_on=False to silence."
+                .format(turn_on, TURN_ON_TIME_MIN))
+            return
+
+        # Only the hill/valley alpha_M branch has a closed-form M_*^2 to test against.
+        try:
+            if int(self._rph_setting('RPHalphaMmodel', 0)) != HILLVALLEY_FLAG:
+                return
+            if not bool(self._rph_setting('RPHusealphaM', True)):
+                return
+            c_M = float(self._rph_setting('RPHalphaM_cM', 0.))
+            tau = float(self._rph_setting('RPHalphaM_tau', 1.))
+            a_t = float(self._rph_setting('RPHalphaM_at', 0.5))
+        except (TypeError, ValueError):
+            return
+        if not (c_M and tau > 0. and a_t > 0.):
+            return
+
+        offset = float(hill_valley_M2(turn_on, c_M, tau, a_t)) - 1.
+        if abs(offset) <= TURN_ON_M2_OFFSET_TOLERANCE:
+            return
+        warnings.warn(
+            "HEFTCAMBEngine: EFTCAMB_turn_on_time = {:g} is too late for this hill/valley model. "
+            "By then M_*^2 = {:.6f}, i.e. {:+.3f}% of the Planck-mass running has already "
+            "happened, and EFTCAMB evolves all of it in general relativity while hi_class / "
+            "mochi-class does not; expect roughly that much error on sigma8 and twice it on "
+            "P(k). Lower it, e.g. extra_params={{'eftcamb_params': {{'EFTCAMB_turn_on_time': "
+            "{:g}}}}}, but do not go below {:g} (see the warning there). Pass "
+            "heftcamb_check_turn_on=False to silence."
+            .format(turn_on, offset + 1., 100. * offset, TURN_ON_TIME_MIN, TURN_ON_TIME_MIN))
 
     def _prune_rph_params(self):
         """Drop RPH shape parameters that the active model flags will not read.
@@ -923,6 +1301,7 @@ class HEFTCAMBEngine(CambEngine):
         # it: c_K/c_B/c_M/c_T/M2_ini are wrapper-private, and they may have
         # arrived either as extra_params or as top-level Cosmology parameters.
         alpha_basis = self._collect_alpha_basis()
+        gravity_model = self._collect_gravity_model()
 
         # Clean only wrapper-private keys.
         # Do NOT remove real EFTCAMB/RPH parameters.
@@ -941,10 +1320,13 @@ class HEFTCAMBEngine(CambEngine):
         # values written into _extra_params win over the untouched class
         # defaults sitting in _params.
         self._apply_alpha_basis(alpha_basis)
+        # After the alpha basis, so that an explicit gravity_model wins over a stray c_B.
+        self._apply_gravity_model(gravity_model)
         self._resolve_default_param_conflicts()
         self._map_w0wa_to_rph()
         self._check_background_consistency()
         self._prune_rph_params()
+        self._check_turn_on_time()
 
         if getattr(self, '_heftcamb_debug', False):
             self._debug_effective_params()
@@ -1021,12 +1403,14 @@ class HEFTCAMBEngine(CambEngine):
             "EFT_additional_priors": bool(EFT_additional_priors),
         }
 
-    @staticmethod
+    @classmethod
     def _build_hillvalley_eftcamb_params(
+        cls,
         *,
         cM=-0.05,
         at=0.5,
         tau=1.0,
+        r=2.0,
         no_slip=True,
         RPH_kinetic0=1.0,
         w0=None,
@@ -1050,14 +1434,21 @@ class HEFTCAMBEngine(CambEngine):
         Stability requires cM < 0, and the extremal amplitude is
         0.385 |cM|, not |cM|.
 
-        With ``no_slip=True`` the braiding is locked to the No Slip Gravity
-        condition alpha_B = -2 alpha_M in the Bellini-Sawicki convention.
-        EFTCAMB stores alpha_B^EFTCAMB = -alpha_B^BS / 2 (see the comment at
-        008p0_Horndeski.f90:1783 and the assignment in 007p2_RPH.f90), so in
-        EFTCAMB's own convention this is alpha_B = +alpha_M: the same
-        functional form with the same three parameters.
+        With ``no_slip=True`` the braiding is locked to alpha_B = -r alpha_M in the
+        Bellini-Sawicki / hi_class convention (eq. 4 of arXiv:1904.12903; r = 2 is
+        No Slip Gravity). EFTCAMB stores alpha_B^EFTCAMB = -alpha_B^BS / 2 (see the
+        comment at 008p0_Horndeski.f90:1783 and the assignment in 007p2_RPH.f90),
+        so the braiding is the same functional form with amplitude
+        +r cM / 2; the conversion is done by
+        :meth:`_braiding_hiclass_to_eftcamb` rather than written out here.
 
         ``w0`` / ``wa`` optionally select a CPL background (RPHwDE = 2).
+
+        Note
+        ----
+        This builds a raw ``eftcamb_params`` dictionary. Prefer the
+        ``gravity_model='hill_valley'`` / ``parameters_smg`` entry point
+        (:meth:`_apply_gravity_model`), which takes mochi-class' own arguments.
         """
         params = {
             # Model selection
@@ -1106,7 +1497,8 @@ class HEFTCAMBEngine(CambEngine):
         if no_slip:
             params.update({
                 "RPHbraidingmodel": HILLVALLEY_FLAG,
-                "RPHbraiding_cM": float(cM),
+                # alpha_B = -r alpha_M in the hi_class convention.
+                "RPHbraiding_cM": cls._braiding_hiclass_to_eftcamb(-float(r) * float(cM)),
                 "RPHbraiding_at": float(at),
                 "RPHbraiding_tau": float(tau),
                 "RPHbraidingmodel_ODE": 0,

--- a/cosmoprimo/heftcamb_stability.py
+++ b/cosmoprimo/heftcamb_stability.py
@@ -1,0 +1,603 @@
+r"""
+Fast, vectorised stability check for the Horndeski models of HEFTCAMB / EFTCAMB.
+
+The companion of :mod:`mochiclass_stability`, for the other engine.  Same purpose --
+gate a linear-:math:`P(k)` emulator without running the Boltzmann code -- and the same
+two parametrisations, but a **different set of conditions**, because EFTCAMB's stability
+module is not a re-spelling of mochi_class'.  If the emulator is trained on ``heftcamb``,
+this is the gate to use; if on ``mochiclass``, use the other one.  They do not always
+agree, and the differences are structural, not numerical:
+
+===========================  ====================  ========================
+condition                    mochi_class           HEFTCAMB
+===========================  ====================  ========================
+scalar gradient              ``c_s^2 >= 0``        ``EFT_gradient >= -tol``
+scalar ghost                 ``D >= 0``            ``EFT_kinetic >= -tol``
+tensor ghost                 ``M_*^2 >= 0``        ``EFTAT >= -eps``
+tensor gradient              ``1 + alpha_T >= 0``  ``EFTDT >= -eps``
+positive Newton constant     --                    ``1 + Omega > 0``
+``alpha_B`` may not cross 2  **yes**               --
+scanned range in ``a``       ``[1e-14, 1]``        ``[1e-8, 1]``
+tolerance                    exactly 0             relative, see below
+===========================  ====================  ========================
+
+The tolerance matters.  EFTCAMB compares against
+``tol = EFTCAMB_stability_threshold * adotoa^2 (1 + Omega)^2`` (default threshold 1e-8)
+rather than against zero, because ``EFT_kinetic`` and ``EFT_gradient`` are assembled from
+:math:`O(\mathcal{H}^2 (1+\Omega)^2)` terms that cancel down to :math:`O(\Omega_{\rm DE})`;
+at early times the difference is round-off and its sign is meaningless.  The tensor tests
+compare against the bare threshold, which is a units inconsistency in the upstream code
+but is reproduced here because the point is to predict what HEFTCAMB does.
+
+What is *not* reproduced: ``EFT_ghost_math_stability``, ``EFT_mass_math_stability``,
+``EFT_mass_stability``, ``EFT_additional_priors``, ``EFT_positivity_bounds`` and
+``EFT_minkowski_limit``.  All six are switched off by ``cosmoprimo``'s ``heftcamb``
+engine (and the last four are off in EFTCAMB itself), so with the default settings they
+never fire.  :func:`stable` will tell you if you ask for a configuration where that
+assumption breaks.
+
+The criterion
+-------------
+Read off ``EFTCAMBModelComputeStabilityFactors`` (``06_abstract_EFTCAMB_model.f90``) and
+the RPH dictionary of ``007p2_RPH.f90``.  With :math:`\mathcal{H}` = ``adotoa`` = ``aH/c``
+and primes now meaning :math:`d/da` (EFTCAMB's convention, not ``d/dln a``):
+
+.. code::
+
+    Omega   = M2 - 1 + alpha_T M2                     (1 + Omega = M2 (1 + alpha_T))
+    c       = (H^2 - Hdot)(Omega + a Omega'/2) - (a H)^2 Omega''/2 + grhov_t (1 + w)/2
+    Gamma1  = (alpha_K M2 H^2 - 2 c) / (4 h0^2 a^2)
+    Gamma2  = (2 alpha_B^EFT M2 - a Omega') H / (h0 a)
+    Gamma3  = -alpha_T M2,  Gamma4 = -Gamma3,  Gamma5 = Gamma3/2,  Gamma6 = 0
+    EFTAT   = 1 + Omega - Gamma4 = M2
+    EFTDT   = 1 + Omega          = M2 (1 + alpha_T)
+
+with ``alpha_B^EFT = -alpha_B(hi_class)/2`` (:data:`BRAIDING_EFTCAMB_OVER_HICLASS`), and
+``EFT_kinetic`` / ``EFT_gradient`` the polynomials transcribed in :func:`eft_kinetic` and
+:func:`eft_gradient`.
+
+Everything is analytic: the background is exactly w0waCDM (shared with
+:mod:`mochiclass_stability`, and checked against HEFTCAMB's own ``adotoa`` to 8e-7 and
+``grhov_t`` to 2e-6), and the alphas and their ``a``-derivatives are closed form.
+
+Validating this against the code
+--------------------------------
+``EFTCAMB_GetEFTFunctions`` -- what ``cosmoprimo`` exposes as ``get_eft_functions`` --
+used to call ``compute_background_EFT_functions`` **before** ``compute_adotoa`` on the
+designer branch (its two branches were swapped relative to ``EFTStabilityComputation``), so
+the ``EFTc`` it reported was evaluated at ``adotoa = Hdot = grhov_t = 0``, i.e. identically
+zero.  ``EFTGamma1V`` and ``EFT_gradient`` inherited that and were wrong by factors of
+10--30; ``EFT_kinetic`` was immune because ``EFTc`` cancels there against
+``8 Gamma1 (1 + Omega)``.  It never touched a verdict -- the stability check has always
+used the correct order -- but it made the dump useless for checking the gradient.
+
+Fixed in ``heftcamb_upstream_fixes.patch`` (a Fortran patch against ``HEFTCAMB_fullshape``,
+kept outside ``cosmoprimo`` -- see `Companion files`_ below), which also adds the missing
+``compute_tensor_factors`` call (``EFTAT``, ``EFTBT``, ``EFTDT`` were reported as zero).
+On a patched build the dump is usable for all of it, and this module agrees with it to
+
+* ``EFT_kinetic`` ~2e-6, ``EFTAT`` / ``EFTDT`` 3e-8
+* ``EFTc`` / ``EFT_gradient`` ~7e-3 -- background-limited, not a discrepancy: rebuilding
+  ``EFTc`` from the dump's *own* ``Omega``, ``adotoa`` and ``Hdot`` reproduces it to 4e-16,
+  and the residual is ``Omega = M2 - 1`` being small where ``adotoa^2`` is large.
+
+``EFTpiA1 ... EFTpiE`` are still reported as zero: ``compute_pi_factors`` needs
+``eft_cache%k``, which this routine has no notion of.  Against an *unpatched* library
+``eft_kinetic`` here differs by up to 48%, by design -- see :func:`eft_kinetic`.  Verdicts
+agree either way, which is checked.
+
+A bug in the engine, now fixed
+------------------------------
+Part of the ``(w0, wa)`` plane used to be silently unusable on this HEFTCAMB build.
+``EFTCAMBRPHSolveDesignerEquations`` (``007p2_RPH.f90``) integrated ``rho_DE`` as a
+**linear** variable: ``y(1) = rho_DE / rho_DE(a_ini)``, which runs from 1 down to
+``a_ini**(3(1+w0+wa)) * exp(3 wa)`` between ``a_ini = 1e-8`` and ``a = 1``.  Whenever that
+fell below the solver's fixed ``atol = 1e-16``, DLSODA stopped controlling it and drove it
+to zero: the dark energy vanished at late times and the run completed -- without raising --
+at ``H0 = sqrt(Omega_m) H0``.  Measured before the fix, on ``w0 = -0.634, wa = +0.478``:
+``H0 = 38.2`` where 67.36 was requested.  It was not the DLSODA step cap (already 100000),
+and an earlier ``rhov_norm`` patch did not cure it -- that rescales the *start* of the
+second pass, which moves the underflow to its end.
+
+Fixed here by integrating the log instead: ``y(1) = log(rho_DE/rho_DE(a_ini))``, obeying
+``ydot = -3(1+w(a))``, which has no ``y`` on the right-hand side, cannot underflow, spans
+only O(50), and is decoupled from the rest of the system.  The physical density is
+``grhov0*exp(y(1) - rhov_lognorm)*a**2``, exact at ``a = 1`` by construction.  The second
+integration pass also no longer downgrades ``istate == -1`` to a warning, so this class of
+failure cannot complete silently again.
+
+After the fix, ``H0`` is correct to <= 4.3e-10 over the whole box, and the previously
+broken models are all labelled correctly.  The diff is saved as
+``heftcamb_upstream_fixes.patch``, with the pre-patch source and library kept beside the
+patched build in ``HEFTCAMB_fullshape/.stability_backup/``.
+
+**Applying it fixes one build.** Anyone on an unpatched HEFTCAMB still has the bug, and
+``cosmoprimo``'s ``_designer_normalisation_is_reliable`` probe does not detect it (it tests
+``w0 = -0.9, wa = -0.5``, which converges either way).  ``validate_heftcamb.py`` keeps its
+own check -- comparing HEFTCAMB's ``H0`` against the requested one -- as a regression guard;
+it is a cheap thing to keep in an emulator training loop for the same reason.
+
+Usage
+-----
+::
+
+    import numpy as np
+    from cosmoprimo import heftcamb_stability as hs
+
+    ok = hs.stable_hill_valley(
+        c_M=np.random.uniform(-0.5, 0.5, n), tau=..., a_t=..., r=2., alpha_K=1e-4,
+        h=0.6736, omega_b=0.02237, omega_cdm=0.12, w0=-0.9, wa=0.36)
+
+Alphas are in the **hi_class / mochi_class** convention throughout, exactly as
+``cosmoprimo``'s ``heftcamb`` engine takes them, so the same numbers go into this module
+and into :mod:`mochiclass_stability`.
+
+.. _Companion files:
+
+Companion files
+---------------
+Two files referred to above are **not** shipped with ``cosmoprimo`` -- they live with the
+rest of the notes in the DESI-DR2-MG ``Stability/`` directory:
+
+* ``heftcamb_upstream_fixes.patch``, the Fortran diff against ``HEFTCAMB_fullshape``:
+  swapped ``EFTCAMB_GetEFTFunctions`` branches, missing ``compute_tensor_factors``, the
+  no-op third pass of ``EFTCAMB_Stability_Check`` (:func:`eftcamb_a_grid`), and the
+  designer ``rho_DE`` underflow.
+* ``validate_heftcamb.py``, which generates ground truth by asking the ``heftcamb`` engine
+  itself and reports the confusion matrix, the pointwise ``EFT_kinetic`` agreement, and how
+  often HEFTCAMB and mochi_class disagree with each other.
+
+This module needs neither -- it is numpy-only and reads nothing from a HEFTCAMB build.
+Against an *unpatched* library the first three fixes cost it nothing: the first two touch
+only the diagnostic dump, and the third changed 0 / 4000 verdicts.  The ``rho_DE``
+underflow is different in kind -- it makes the engine return a ``P(k)`` at the wrong
+``H0`` rather than raise -- so on an unpatched build the disagreements it causes are the
+engine's, not this module's.
+"""
+
+import numpy as np
+
+from . import mochiclass_stability as mcs
+from .mochiclass_stability import background, alphas_hill_valley
+
+__all__ = ['stable', 'stable_hill_valley', 'stable_propto_omega',
+           'scan_hill_valley', 'scan_propto_omega',
+           'eft_functions', 'eft_kinetic', 'eft_gradient',
+           'default_a_grid', 'eftcamb_a_grid']
+
+
+#: ``alpha_B(EFTCAMB) = -0.5 alpha_B(hi_class)``; see ``cosmoprimo/heftcamb.py``.
+BRAIDING_EFTCAMB_OVER_HICLASS = -0.5
+
+#: ``EFTCAMB_stability_time``: where the scan starts.  1e-8 is what ``cosmoprimo`` sets
+#: (EFTCAMB's own default of 1e-10 precedes the designer background grid).
+A_START = 1e-8
+
+#: ``EFTCAMB_stability_threshold``: the relative tolerance on the kinetic and gradient
+#: terms.  EFTCAMB's default.
+STABILITY_THRESHOLD = 1e-8
+
+#: ``indMax`` in ``EFTCAMB_Stability_Check``: points per sampling pass.
+N_EFTCAMB_SAMPLE = 1000
+
+#: Default number of grid points; see :func:`default_a_grid`.
+DEFAULT_NA = 512
+
+#: Mpc per unit ``h`` in ``H0``: ``h0_Mpc = h / _C_OVER_100``.
+_C_OVER_100 = 2997.92458458
+
+
+def eftcamb_a_grid(a_start=A_START, n=N_EFTCAMB_SAMPLE):
+    r"""
+    EFTCAMB's own stability sampler, reproduced exactly.
+
+    ``EFTCAMB_Stability_Check`` makes three passes of ``n`` points over ``[a_start, 1]``:
+    a linear one, a log one bunched at ``a_start``
+    (:math:`a = a_{\rm start} + (1 - a_{\rm start}) 10^{y}`, :math:`y \in [-10, 0]`), and a
+    third bunched at ``a = 1`` (:math:`a = 1 + (a_{\rm start} - 1) 10^{y}`).
+
+    The third pass was a no-op upstream -- ``y`` was never reassigned inside that loop, so
+    it kept the value 0 left by the previous one and every iteration re-tested ``a_start``.
+    Fixed in ``heftcamb_upstream_fixes.patch`` and included here.  It is inert in practice:
+    the linear pass already reaches ``a = 1`` and the terms are smooth there, so restoring
+    the 1000 extra points changed 0 / 4000 verdicts on a broad prior.
+    """
+    lin = np.linspace(a_start, 1., int(n))
+    y = np.linspace(-10., 0., int(n))
+    log_start = a_start + (1. - a_start) * 10.**y
+    log_end = 1. + (a_start - 1.) * 10.**y
+    return np.unique(np.concatenate([lin, log_start, log_end]))
+
+
+def default_a_grid(na=DEFAULT_NA, a_start=A_START, a_split=1e-3, frac_early=0.25):
+    """
+    A cheaper stand-in for :func:`eftcamb_a_grid`, in the spirit of
+    :func:`mochiclass_stability.default_a_grid`: log-spaced in two pieces, dense where the
+    structure is.
+
+    ``validate_heftcamb.py`` measures what it costs relative to the exact sampler.
+    """
+    na = int(na)
+    ne = max(2, int(na * frac_early))
+    return np.concatenate([np.logspace(np.log10(a_start), np.log10(a_split), ne, endpoint=False),
+                           np.logspace(np.log10(a_split), 0., na - ne)])
+
+
+# --------------------------------------------------------------------------------------
+# RPH alphas and their a-derivatives
+#
+# EFTCAMB differentiates with respect to a, not ln a, so everything below carries the
+# 1/a factors explicitly.  With u = (tau/2) ln(a/a_t) and du/dln a = tau/2,
+#
+#     alpha_M      = c_M tanh u sech^2 u
+#     dalpha_M/dln a = c_M (tau/2) sech^2 u (sech^2 u - 2 tanh^2 u)
+#     M_*^2        = M2_ini exp[-(c_M/tau) sech^2 u]
+#
+# built from x2 = exp(-2|u|) exactly as gravity_models_hill_valley_smg does, so that they
+# stay exact where cosh u would overflow.
+# --------------------------------------------------------------------------------------
+def _hill_valley_pieces(a, c_M, tau, a_t, M2_ini):
+    """``alpha_M``, ``dalpha_M/dln a`` and ``M_*^2`` for the hill/valley parametrisation."""
+    u = 0.5 * tau * np.log(a / a_t)
+    x2 = np.exp(-2. * np.abs(u))
+    opx2 = 1. + x2
+    sech2 = 4. * x2 / opx2**2
+    tanh_u = np.sign(u) * (1. - x2) / opx2
+    alpha_M = c_M * tanh_u * sech2
+    dalpha_M = c_M * (0.5 * tau) * sech2 * (sech2 - 2. * tanh_u**2)
+    M2 = M2_ini * np.exp(-(c_M / tau) * sech2)
+    return alpha_M, dalpha_M, M2
+
+
+def _rph_hill_valley(a, c_M, tau, a_t, r, M2_ini, alpha_K):
+    """
+    ``(alpha_K, alpha_M, dalpha_M/da, alpha_B_hi, dalpha_B_hi/da, alpha_T, alpha_T', alpha_T'', M2)``.
+
+    ``alpha_K`` is a genuine constant here -- ``parameters_smg[0]``, mapped by
+    ``cosmoprimo`` onto ``RPHkineticitymodel=1`` (constant) -- so it passes straight
+    through.  Contrast :func:`_rph_propto_omega`.
+    """
+    alpha_M, dalpha_M_dlna, M2 = _hill_valley_pieces(a, c_M, tau, a_t, M2_ini)
+    z = np.zeros_like(alpha_M + a)
+    return (alpha_K + z, alpha_M, dalpha_M_dlna / a,
+            -r * alpha_M, -r * dalpha_M_dlna / a,
+            z, z, z, M2)
+
+
+def _rph_propto_omega(a, lna, bg, c_k, c_b, c_m, c_t, M2_ini):
+    r"""
+    Same tuple for ``propto_omega``, :math:`\alpha_i = c_i \Omega_{\rm smg}(a)`.
+
+    HEFTCAMB's ``Ode = grhov/(3 H^2)`` is mochi_class' ``Omega_smg`` (``007p2_RPH.f90``
+    line 1362), so the shape function is shared with :mod:`mochiclass_stability`.
+    :math:`M_\ast^2` comes from the same cumulative trapezoid of
+    :math:`\int \alpha_M\,d\ln a`; ``RPHintegratefromtoday=False`` makes ``M2_ini`` the
+    early-time value on both sides.
+
+    Converting log- to ``a``-derivatives: :math:`d/da = a^{-1} d/d\ln a` and
+    :math:`d^2/da^2 = a^{-2}(d^2/d\ln a^2 - d/d\ln a)`.
+    """
+    Om, dOm, d2Om = bg['Omega_de'], bg['dOmega_de'], bg['d2Omega_de']
+    dl = np.diff(lna, axis=-1)
+    integ = np.concatenate([np.zeros(Om.shape[:-1] + (1,)),
+                            np.cumsum(0.5 * (Om[..., 1:] + Om[..., :-1]) * dl, axis=-1)], axis=-1)
+    M2 = M2_ini * np.exp(c_m * integ)
+    # alpha_K runs too: c_k is RPHkineticity_ODE0, and alpha_K(a) = c_k Omega_smg(a).
+    # It does not matter to mochi_class (alpha_K cancels out of the gradient test) but it
+    # is the leading term of EFT_kinetic at early times, where a constant alpha_K would
+    # make the kinetic term diverge like adotoa^2 instead of vanishing.
+    return (c_k * Om, c_m * Om, c_m * dOm / a,
+            c_b * Om, c_b * dOm / a,
+            c_t * Om, c_t * dOm / a, c_t * (d2Om - dOm) / a**2,
+            M2)
+
+
+# --------------------------------------------------------------------------------------
+# EFT functions
+# --------------------------------------------------------------------------------------
+def eft_functions(a, bg, h, alpha_K, alpha_M, dalpha_M, alpha_B_hi, dalpha_B_hi,
+                  alpha_T, dalpha_T, d2alpha_T, M2):
+    # NOTE alpha_K is a function of a in general (propto_omega), not the input constant.
+    """
+    The EFT-basis quantities EFTCAMB's stability module reads, from the RPH alphas.
+
+    ``alpha_B_hi`` is in the hi_class convention and is converted here; ``dalpha_*`` are
+    ``d/da``.  Returns a dict with the pieces :func:`eft_kinetic` and :func:`eft_gradient`
+    need, plus ``EFTAT`` / ``EFTDT`` / ``one_plus_Omega`` for the tensor and
+    Newton-constant tests, and ``tol`` for the relative comparison.
+    """
+    h0 = h / _C_OVER_100
+    E2, P_tot = bg['E2'], bg['P_tot']
+    ad = a * h0 * np.sqrt(E2)                       # adotoa = a H / c
+    Hdot = ad**2 * (1. - 1.5 * (1. + P_tot))        # d(adotoa)/d(conformal time)
+    grhov = 3. * h0**2 * bg['Omega_de'] * E2 * a**2  # 8 pi G rho_de a^2
+    w = bg['w']
+
+    AB = BRAIDING_EFTCAMB_OVER_HICLASS * alpha_B_hi
+    AB_P = BRAIDING_EFTCAMB_OVER_HICLASS * dalpha_B_hi
+
+    Mp1 = M2
+    PM_V = M2 - 1.
+    PM_P = alpha_M * Mp1 / a
+    PM_PP = ((-alpha_M + alpha_M**2 + a * dalpha_M) * Mp1) / a**2
+
+    OmV = PM_V + alpha_T * Mp1
+    OmP = PM_P + alpha_T * PM_P + dalpha_T * Mp1
+    OmPP = PM_PP + alpha_T * PM_PP + 2. * dalpha_T * PM_P + d2alpha_T * Mp1
+
+    c = ((ad**2 - Hdot) * (OmV + 0.5 * a * OmP) - 0.5 * (a * ad)**2 * OmPP
+         + 0.5 * grhov * (1. + w))
+    G1V = 0.25 * (alpha_K * Mp1 * ad**2 - 2. * c) / (h0**2 * a**2)
+    G2V = (2. * AB * Mp1 - a * OmP) * ad / (h0 * a)
+    G2P = (-(2. * AB * Mp1 - a * OmP) * ad / (h0 * a**2)
+           - (-2. * Mp1 * (AB_P * ad**2 + AB * Hdot / a) - 2. * AB * ad**2 * PM_P
+              + OmP * (ad**2 + Hdot) + a * ad**2 * OmPP) / (h0 * a * ad))
+    G3V = -alpha_T * Mp1
+    G3P = -PM_P * alpha_T - Mp1 * dalpha_T
+    G4V, G4P = -G3V, -G3P
+    G5V, G5P = 0.5 * G3V, 0.5 * G3P
+
+    one_plus_Omega = 1. + OmV
+    return {'a': a, 'h0': h0, 'adotoa': ad, 'Hdot': Hdot, 'EFTc': c,
+            # alpha_T = 0 kills Gamma3, Gamma4 and Gamma5 outright, which removes most of
+            # the gradient polynomial.  Recorded here so eft_gradient can take the short
+            # route; the two branches are algebraically identical.
+            'alpha_T_zero': not np.any(alpha_T),
+            'OmegaV': OmV, 'OmegaP': OmP, 'OmegaPP': OmPP,
+            'Gamma1V': G1V, 'Gamma2V': G2V, 'Gamma2P': G2P,
+            'Gamma4V': G4V, 'Gamma4P': G4P, 'Gamma5V': G5V, 'Gamma5P': G5P,
+            'one_plus_Omega': one_plus_Omega,
+            'EFTAT': one_plus_Omega - G4V, 'EFTDT': one_plus_Omega,
+            'tol': STABILITY_THRESHOLD * ad**2 * one_plus_Omega**2}
+
+
+def eft_kinetic(f):
+    """
+    ``EFT_kinetic``, transcribed from ``06_abstract_EFTCAMB_model.f90`` line 555.
+
+    Reproduces HEFTCAMB's own array to ~1e-6 relative on a single model, 5.5e-5 worst case
+    over a broad prior.  Note that ``EFTc`` cancels
+    identically between the ``4 c (1+Omega-Gamma4)`` term and ``8 Gamma1 (1+Omega-Gamma4)``
+    -- which is why this one quantity survives the ``get_eft_functions`` ordering bug
+    described in the module docstring.
+
+    The ``6 adotoa Gamma2 OmegaP`` cross term takes one power of ``h0``, not two.  Upstream
+    it sat inside the inner bracket, which left it dimensionally inconsistent with its
+    neighbours and suppressed by ``h0 ~ 2e-4`` -- effectively dropped.  Placed as below, and
+    with ``alpha_T = 0`` for definiteness, the expression collapses exactly to
+
+    .. code::
+
+        EFT_kinetic = 18 M2^3 adotoa^2 ( alpha_K + 3/2 alpha_B^2 ) = 18 M2^3 adotoa^2 D
+
+    the standard Horndeski no-ghost quantity, carrying the same ``18 M2^3 adotoa^2``
+    prefactor as ``EFT_gradient = 18 M2^3 adotoa^2 cs2num``.  With the stray ``h0`` it does
+    not.  Checked to 1e-12 relative against :func:`mochiclass_stability.kinetic_D`; the
+    matching HEFTCAMB fix is in ``heftcamb_upstream_fixes.patch``.
+
+    This changes no verdict for ``alpha_K >= 0``: both forms are ``2 alpha_K`` plus a sum of
+    squares, so neither can go negative there and the ghost test cannot fire either way.  It
+    matters for the *reported* value (wrong by up to 48%), and for ``alpha_K < 0``.
+    """
+    a, ad, h0 = f['a'], f['adotoa'], f['h0']
+    opo = f['one_plus_Omega'] - f['Gamma4V']
+    return 9. * opo * (4. * f['EFTc'] * opo + 3. * ad**2 * f['OmegaP']**2 * a**2
+                       + a**2 * h0 * (h0 * (3. * f['Gamma2V']**2 + 8. * f['Gamma1V'] * opo)
+                                      + 6. * ad * f['Gamma2V'] * f['OmegaP']))
+
+
+def eft_gradient(f):
+    """
+    ``EFT_gradient``, transcribed from ``06_abstract_EFTCAMB_model.f90`` line 559.
+
+    Cannot be validated against ``get_eft_functions`` -- that dump evaluates it with
+    ``EFTc = 0`` (see the module docstring) -- so it is validated through the verdict
+    instead, in ``validate_heftcamb.py``.
+
+    When ``alpha_T`` vanishes identically (always, for hill/valley) every ``Gamma4`` and
+    ``Gamma5`` term drops and the polynomial collapses to four terms.  That branch is
+    taken automatically; ``validate_heftcamb.py`` checks the two against each other.
+    """
+    a, ad, h0, Hdot, c = f['a'], f['adotoa'], f['h0'], f['Hdot'], f['EFTc']
+    if f.get('alpha_T_zero'):
+        OV, OP = f['OmegaV'], f['OmegaP']
+        G2V, G2P = f['Gamma2V'], f['Gamma2P']
+        opo = 1. + OV
+        return 9. * (3. * a**2 * ad**2 * OP**2 * opo - a**2 * G2V**2 * h0**2 * opo
+                     + 4. * c * opo**2
+                     - 2. * a * ad * h0 * (a * G2P * opo**2 + G2V * opo * (opo - a * OP)))
+    OV, OP, OPP = f['OmegaV'], f['OmegaP'], f['OmegaPP']
+    G2V, G2P = f['Gamma2V'], f['Gamma2P']
+    G4V, G4P, G5V, G5P = f['Gamma4V'], f['Gamma4P'], f['Gamma5V'], f['Gamma5P']
+    return 9. * (
+        8. * a * ad**2 * G5P - 16. * ad**2 * G5V**2 + 16. * c * G5V**2
+        - 2. * a**2 * ad**2 * G4P * OP + 4. * a**2 * ad**2 * G5P * OP
+        - 4. * a * ad**2 * G5V * OP - 4. * a**2 * ad**2 * G4P * G5V * OP
+        - 8. * a * ad**2 * G5V**2 * OP + 3. * a**2 * ad**2 * OP**2
+        + 4. * a**2 * ad**2 * G5V * OP**2 + 16. * a * ad**2 * G5P * OV
+        + 16. * c * G5V * OV - 16. * ad**2 * G5V**2 * OV
+        - 2. * a**2 * ad**2 * G4P * OP * OV + 4. * a**2 * ad**2 * G5P * OP * OV
+        - 4. * a * ad**2 * G5V * OP * OV + 3. * a**2 * ad**2 * OP**2 * OV
+        + 8. * a * ad**2 * G5P * OV**2
+        - a**2 * G2V**2 * h0**2 * (1. + OV)
+        + 4. * a**2 * ad**2 * G5V * OPP * (1. + 2. * G5V + OV)
+        + 4. * c * (4. * G5V + (1. + OV)**2)
+        - 2. * a * ad * h0 * (a * G2P * (1. - G4V + OV) * (1. + 2. * G5V + OV)
+                              + G2V * (G4V * (-1. + 2. * a * G5P + 2. * G5V + a * OP - OV)
+                                       + (1. + OV) * (1. + a * (G4P - 2. * G5P - OP) + OV)
+                                       - 2. * G5V * (1. - a * G4P + a * OP + OV)))
+        + 8. * G5V * Hdot + 16. * G5V**2 * Hdot + 4. * a * G5V * OP * Hdot
+        + 8. * a * G5V**2 * OP * Hdot + 16. * G5V * OV * Hdot
+        + 16. * G5V**2 * OV * Hdot + 4. * a * G5V * OP * OV * Hdot
+        + 8. * G5V * OV**2 * Hdot
+        + 4. * G4V**2 * (ad**2 * (1. + 2. * a * G5P + 4. * G5V + a * OP + OV)
+                         - (1. + 2. * G5V + OV) * Hdot)
+        + 2. * G4V * (ad**2 * (-(a**2 * OP**2) + a**2 * OPP * (1. + 2. * G5V + OV)
+                               - 4. * (1. + OV) * (1. + 2. * a * G5P + 4. * G5V + OV)
+                               - a * OP * (3. + 2. * a * G5P + 2. * G5V + 3. * OV))
+                      + (1. + 2. * G5V + OV) * (4. + a * OP + 4. * OV) * Hdot))
+
+
+# --------------------------------------------------------------------------------------
+# Drivers
+# --------------------------------------------------------------------------------------
+_COSMO_KEYS = mcs._COSMO_KEYS
+_CHUNK_ELEMENTS = mcs._CHUNK_ELEMENTS
+
+#: Stability flags this module does *not* reproduce.  All are off in ``cosmoprimo``'s
+#: ``heftcamb`` engine; :func:`stable` refuses to answer if you say one is on.
+_UNSUPPORTED_FLAGS = ('EFT_ghost_math_stability', 'EFT_mass_math_stability',
+                      'EFT_mass_stability', 'EFT_additional_priors',
+                      'EFT_positivity_bounds', 'EFT_minkowski_limit')
+
+
+def _check_flags(flags):
+    if not flags:
+        return
+    on = sorted(k for k in _UNSUPPORTED_FLAGS if flags.get(k))
+    if on:
+        raise ValueError(
+            'heftcamb_stability reproduces only the ghost and gradient conditions '
+            '(EFT_ghost_stability / EFT_gradient_stability), which is what cosmoprimo\'s '
+            'heftcamb engine switches on. It cannot predict a run with {} enabled.'
+            .format(', '.join(on)))
+
+
+def _refined_grid(a_grid, a_t, tau, a_start, u_max=8., n_refine=96):
+    """Per-model window around the hill/valley transition; see the mochiclass twin."""
+    u = np.linspace(-u_max, u_max, int(n_refine))
+    a_ref = np.clip(a_t[:, None] * np.exp(2. * u[None, :] / tau[:, None]), a_start, 1.)
+    return np.concatenate([np.broadcast_to(a_grid, (a_t.size, a_grid.size)), a_ref], axis=-1)
+
+
+def _scan(model, par, cosmo_keys, a_grid, refine, n_refine, chunk, a_start):
+    """One sweep of the ``a`` grid, returning everything EFTCAMB reduces over it."""
+    n = len(next(iter(par.values())))
+    lna = np.log(a_grid)
+    width = a_grid.size + (n_refine if refine else 0)
+    nchunk = chunk or max(1, _CHUNK_ELEMENTS // width)
+
+    keys = ('min_kinetic', 'min_gradient', 'min_AT', 'min_DT', 'min_one_plus_Omega')
+    out = {k: np.empty(n) for k in keys}
+    for i in range(0, n, nchunk):
+        sl = slice(i, min(i + nchunk, n))
+        p = {k: v[sl][:, None] for k, v in par.items()}
+        bgkw = {k: p[k] for k in cosmo_keys}
+        if model == 'hill_valley':
+            a = (_refined_grid(a_grid, par['a_t'][sl], par['tau'][sl], a_start,
+                               n_refine=n_refine) if refine else a_grid)
+            bg = background(a, derivs=False, **bgkw)
+            rph = _rph_hill_valley(a, p['c_M'], p['tau'], p['a_t'], p['r'], p['M2_ini'],
+                                   p['alpha_K'])
+        else:
+            a = a_grid
+            bg = background(a, derivs=True, **bgkw)
+            rph = _rph_propto_omega(a, lna, bg, p['alpha_K'], p['c_b'], p['c_m'],
+                                    p['c_t'], p['M2_ini'])
+        f = eft_functions(a, bg, p['h'], *rph)
+        tol = f['tol']
+        # EFTCAMB tests "< -tol" pointwise, and tol depends on a, so the margin has to be
+        # minimised, not the bare term.
+        out['min_kinetic'][sl] = (eft_kinetic(f) + tol).min(axis=-1)
+        out['min_gradient'][sl] = (eft_gradient(f) + tol).min(axis=-1)
+        shape = f['adotoa'].shape
+        out['min_AT'][sl] = np.broadcast_to(f['EFTAT'], shape).min(axis=-1)
+        out['min_DT'][sl] = np.broadcast_to(f['EFTDT'], shape).min(axis=-1)
+        out['min_one_plus_Omega'][sl] = np.broadcast_to(f['one_plus_Omega'], shape).min(axis=-1)
+    return out
+
+
+def _prepare(args, cosmo, na, a_grid, a_start):
+    bad = set(cosmo) - set(_COSMO_KEYS)
+    if bad:
+        raise TypeError('unexpected argument(s) {}; expected model parameters or one of {}'
+                        .format(sorted(bad), list(_COSMO_KEYS)))
+    if 'h' not in cosmo:
+        cosmo = dict(cosmo, h=0.6736)
+    names = list(args) + list(cosmo)
+    par, shape, n = mcs._broadcast(names, list(args.values()) + list(cosmo.values()))
+    grid = default_a_grid(na, a_start) if a_grid is None else np.asarray(a_grid, dtype='f8')
+    return par, shape, n, grid, list(cosmo)
+
+
+def scan_hill_valley(c_M, tau, a_t, r=2., M2_ini=1., alpha_K=1e-4, na=DEFAULT_NA,
+                     a_grid=None, a_start=A_START, refine=True, n_refine=96, chunk=None,
+                     **cosmo):
+    """
+    Everything EFTCAMB minimises over ``a``, for the hill/valley parametrisation.
+
+    Returns a dict of arrays: ``min_kinetic`` and ``min_gradient`` are the *margins*
+    (term + tolerance, so ``>= 0`` passes), ``min_AT`` / ``min_DT`` /
+    ``min_one_plus_Omega`` are the bare minima.  ``alpha_K`` is a real argument here,
+    unlike in :mod:`mochiclass_stability`: it enters ``EFT_kinetic`` through ``Gamma1``.
+    """
+    args = dict(c_M=c_M, tau=tau, a_t=a_t, r=r, M2_ini=M2_ini, alpha_K=alpha_K)
+    par, shape, n, grid, ck = _prepare(args, cosmo, na, a_grid, a_start)
+    out = _scan('hill_valley', par, ck, grid, refine, n_refine, chunk, a_start)
+    return {k: (v.reshape(shape) if shape else v[0]) for k, v in out.items()}
+
+
+def scan_propto_omega(c_b, c_m, c_t=0., M2_ini=1., alpha_K=1., na=DEFAULT_NA,
+                      a_grid=None, a_start=A_START, chunk=None, **cosmo):
+    """Same, for ``propto_omega``.  The grid must stay sorted (``M_*^2`` is a running integral)."""
+    args = dict(c_b=c_b, c_m=c_m, c_t=c_t, M2_ini=M2_ini, alpha_K=alpha_K)
+    par, shape, n, grid, ck = _prepare(args, cosmo, na, a_grid, a_start)
+    out = _scan('propto_omega', par, ck, grid, False, 0, chunk, a_start)
+    return {k: (v.reshape(shape) if shape else v[0]) for k, v in out.items()}
+
+
+def _verdict(s):
+    """
+    EFTCAMB's verdict from a scan, with ``cosmoprimo``'s default flags.
+
+    ``EFT_ghost_stability`` gives the kinetic and tensor-ghost tests plus the positive
+    Newton constant; ``EFT_gradient_stability`` gives the gradient and tensor-gradient
+    tests plus the same Newton-constant test.  Both are on by default.
+    """
+    ok = s['min_kinetic'] >= 0.
+    ok = np.logical_and(ok, s['min_gradient'] >= 0.)
+    ok = np.logical_and(ok, s['min_AT'] >= -STABILITY_THRESHOLD)
+    ok = np.logical_and(ok, s['min_DT'] >= -STABILITY_THRESHOLD)
+    ok = np.logical_and(ok, s['min_one_plus_Omega'] > 0.)
+    return ok
+
+
+def stable_hill_valley(c_M, tau, a_t, r=2., M2_ini=1., alpha_K=1e-4, flags=None, **kwargs):
+    """``True`` where HEFTCAMB would run the model, ``False`` where it would abort."""
+    _check_flags(flags)
+    return _verdict(scan_hill_valley(c_M, tau, a_t, r=r, M2_ini=M2_ini,
+                                     alpha_K=alpha_K, **kwargs))
+
+
+def stable_propto_omega(c_b, c_m, c_t=0., M2_ini=1., alpha_K=1., flags=None, **kwargs):
+    """``True`` where HEFTCAMB would run the model, ``False`` where it would abort."""
+    _check_flags(flags)
+    return _verdict(scan_propto_omega(c_b, c_m, c_t=c_t, M2_ini=M2_ini,
+                                      alpha_K=alpha_K, **kwargs))
+
+
+def stable(gravity_model, parameters_smg, flags=None, **cosmo):
+    """
+    Dispatch on mochi_class' ``gravity_model`` / ``parameters_smg`` pair.
+
+    Deliberately the same signature as :func:`mochiclass_stability.stable`, since
+    ``cosmoprimo``'s ``heftcamb`` engine takes the same arguments as its ``mochiclass``
+    one -- so the two gates are drop-in swaps for each other.
+    """
+    p = np.asarray(parameters_smg, dtype='f8')
+    if gravity_model in ('hill_valley', 'no_slip_gravity'):
+        if p.shape[-1] != 6:
+            raise ValueError('hill_valley expects parameters_smg = [alpha_K, c_M, tau, '
+                             'a_t, r, M2_ini] on the last axis, got {}'.format(p.shape))
+        aK, c_M, tau, a_t, r, M2_ini = (p[..., i] for i in range(6))
+        return stable_hill_valley(c_M, tau, a_t, r=r, M2_ini=M2_ini, alpha_K=aK,
+                                  flags=flags, **cosmo)
+    if gravity_model == 'propto_omega':
+        if p.shape[-1] != 5:
+            raise ValueError('propto_omega expects parameters_smg = [alpha_K, c_b, c_m, '
+                             'c_t, M2_ini] on the last axis, got {}'.format(p.shape))
+        aK, c_b, c_m, c_t, M2_ini = (p[..., i] for i in range(5))
+        return stable_propto_omega(c_b, c_m, c_t=c_t, M2_ini=M2_ini, alpha_K=aK,
+                                   flags=flags, **cosmo)
+    raise ValueError("gravity_model must be 'hill_valley' ('no_slip_gravity') or "
+                     "'propto_omega', got {!r}".format(gravity_model))

--- a/cosmoprimo/mochiclass_stability.py
+++ b/cosmoprimo/mochiclass_stability.py
@@ -1,0 +1,730 @@
+r"""
+Fast, vectorised gradient-stability check for the Horndeski models of mochi_class.
+
+Purpose
+-------
+A linear-:math:`P(k)` emulator has no way of knowing whether the model it is being
+asked about is physically viable.  mochi_class answers that question by running the
+Boltzmann code and letting it abort (``stability_tests_smg`` in
+``gravity_smg/background_smg.c``); at ~0.1 s per background that is far too slow to
+gate an emulator call.  This module reproduces the same decision analytically, for
+millions of models at a time.
+
+What is (and is not) checked
+----------------------------
+mochi_class runs four tests on the background table::
+
+    min D    >= -|D_safe_smg|      ghost, scalar
+    min c_s^2 > -|cs2_safe_smg|    gradient, scalar
+    min M_*^2 >= -|M2_safe_smg|    ghost, tensor
+    min c_t^2 >= -|ct2_safe_smg|   gradient, tensor
+
+with the ``*_safe_smg`` thresholds all 0 by default.  Here
+
+* ``D = alpha_K + 3/2 alpha_B^2`` is positive whenever ``alpha_K > 0``, so the scalar
+  no-ghost test is vacuous by construction and is skipped (:func:`kinetic_D` is
+  provided if you want to assert it);
+* ``c_t^2 = 1 + alpha_T`` and ``M_*^2 > 0`` are trivial for the two models here
+  (``alpha_T = 0`` for hill_valley; ``M_*^2 = M2_ini exp(int alpha_M dlna) > 0``
+  always).  :func:`stable` checks them anyway -- they cost nothing.
+
+That leaves the **gradient instability**, which is what this module is really about.
+
+There is a fifth condition, and it is easy to miss.  ``background_solve_smg``
+(``background_smg.c:1108``) refuses outright any model whose braiding **crosses 2**,
+because ``2 - alpha_B`` sits in the denominator of the perturbation equations.  It is
+*not* gated by ``skip_stability_tests_smg``, so a run made with that flag set -- the
+obvious way to generate training labels -- still raises on it.  For ``propto_omega`` it
+is not a corner case: ``alpha_B = c_b Omega_smg`` sweeps from 0 up to
+``c_b Omega_smg,0``, so every ``c_b`` above roughly 2.9 is rejected on these grounds
+alone.  :func:`stable` applies it.
+
+Mathematical stability (``skip_math_stability_smg``) is a perturbation-level test and is
+not reproduced here -- and does not need to be: it is ``_TRUE_`` (i.e. skipped) by
+default in ``input_default_params_smg``.
+
+The criterion
+-------------
+Read off ``gravity_functions_As_from_alphas_smg`` (``gravity_smg/gravity_functions_smg.c``),
+with ``bra = alpha_B``, ``run = alpha_M``, ``ten = alpha_T``, ``kin = alpha_K``:
+
+.. code::
+
+    D      = kin + 3/2 bra^2
+    lam2   = -3/2 X_m (bra - 2 dM2/M2) - 3/2 X_de (bra - 2) + dbra/dlna
+    cs2num = (bra - 2)(-bra - 2 run + 2 ten - bra ten)/2 + lam2
+    c_s^2  = cs2num / D
+
+where ``dM2 = M_*^2 - 1`` and, with ``H^2 = rho_tot`` in CLASS' units (the Friedmann
+equation carries *no* factor of ``M_*^2``: for these parametrisations the background is
+exactly w0waCDM, with ``rho_smg`` absorbing everything),
+
+.. code::
+
+    X_m  = (rho_tot,wo_smg + p_tot,wo_smg) / H^2
+    X_de = (rho_smg + p_smg) / H^2 = (1 + w(a)) Omega_smg(a)
+
+``cs2num`` as assembled here reproduces mochi_class' own ``cs2num`` column to 1e-15
+relative -- it is the same expression, not an approximation.  Since ``D > 0``,
+``min_a c_s^2 < 0`` if and only if ``min_a cs2num < 0``, so the whole gradient test
+reduces to the sign of ``cs2num`` and **never involves alpha_K at all**.
+
+The only approximation is therefore the *background*, and even that is exact up to the
+Fermi-Dirac quadrature for massive neutrinos (:data:`_NCDM_RHO`), which is calibrated
+against CLASS itself.  See below for where the measured agreement is produced.
+
+Validation, and where it lives
+------------------------------
+The measured agreement with mochi_class -- pointwise ``cs2num``, the confusion matrix of
+the verdict, and the displacement of the decision boundary, which is the number that
+really sets the error rate -- is produced by ``validate_stability.py`` and
+``validate_boundary.py``.  Those two scripts are **not** part of ``cosmoprimo``: they need
+a working ``pyclass.mochiclass`` to generate ground truth, and they live with the rest of
+the notes in the DESI-DR2-MG ``Stability/`` directory.  Nothing here imports them, and the
+module itself is numpy-only.
+
+Conventions
+-----------
+All alpha functions are in the **hi_class / mochi_class** convention, not EFTCAMB's
+(EFTCAMB's braiding is ``-1/2`` of the one used here; ``cosmoprimo``'s ``heftcamb``
+engine applies that internally).  Note also that EFTCAMB's own stability module uses a
+different, non-equivalent set of conditions -- this module reproduces *mochi_class*.
+
+Usage
+-----
+Every parameter broadcasts, so a whole prior sample goes through in one call::
+
+    import numpy as np
+    from cosmoprimo import mochiclass_stability as mcs
+
+    n = 1_000_000
+    ok = mcs.stable_hill_valley(
+        c_M=np.random.uniform(-0.5, 0.5, n),
+        tau=np.random.uniform(0.5, 5., n),
+        a_t=np.random.uniform(0.1, 1., n),
+        r=2.,
+        omega_cdm=np.random.uniform(0.10, 0.14, n),
+        omega_b=0.02237, h=0.6736, w0=-0.9, wa=0.36)
+
+``ok`` is a boolean array: ``True`` where mochi_class would run the model.
+"""
+
+import numpy as np
+
+__all__ = ['stable', 'stable_hill_valley', 'stable_propto_omega', 'class_a_grid',
+           'class_a_grid',
+           'scan_hill_valley', 'scan_propto_omega',
+           'min_cs2num_hill_valley', 'min_cs2num_propto_omega',
+           'cs2num', 'kinetic_D', 'background', 'default_a_grid',
+           'alphas_hill_valley', 'alphas_propto_omega']
+
+
+# --------------------------------------------------------------------------------------
+# CLASS' own physical constants (include/background.h), so that the background matches
+# mochi_class rather than some other rounding of the same physics.
+# --------------------------------------------------------------------------------------
+_c_ = 2.99792458e8
+_G_ = 6.67428e-11
+_k_B_ = 1.3806504e-23
+_h_P_ = 6.62606896e-34
+_eV_ = 1.602176487e-19
+_Mpc_over_m_ = 3.085677581282e22
+_sigma_B_ = 2. * np.pi**5 * _k_B_**4 / 15. / _h_P_**3 / _c_**2
+
+#: CLASS' ``T_ncdm_default``; chosen so that m / omega_ncdm = 93.14 eV.
+T_NCDM_DEFAULT = 0.71611
+
+#: CLASS' ``a_ini_over_a_today_default``: where the background table, and hence the
+#: stability scan, starts.
+A_INI = 1e-14
+
+#: Number of rows in mochi_class' background table (uniform in ln a over [A_INI, 1]),
+#: i.e. the sampling on which ``min_cs2_smg`` is actually evaluated.
+N_CLASS_TABLE = 3000
+
+#: Default number of grid points.  See :func:`default_a_grid` for why 512 non-uniform
+#: points are worth more than 3000 uniform ones.
+DEFAULT_NA = 512
+
+
+def omega_g(T_cmb=2.7255):
+    """:math:`\\Omega_\\gamma h^2`, verbatim from CLASS' ``input.c`` (line 2474)."""
+    return ((4. * _sigma_B_ / _c_ * np.asarray(T_cmb, dtype='f8')**4)
+            / (3. * _c_**2 * 1.e10 / _Mpc_over_m_**2 / 8. / np.pi / _G_))
+
+
+# --------------------------------------------------------------------------------------
+# Massive neutrinos.
+#
+# rho_ncdm(a) and p_ncdm(a) are pure Fermi-Dirac integrals of the single dimensionless
+# combination y = a M, M = m / T_ncdm,0.  Tabulating them once, as a *universal* pair of
+# functions, makes massive neutrinos exact rather than approximate at negligible cost:
+#
+#     Irho(y) = int_0^inf q^2 sqrt(q^2 + y^2) / (e^q + 1) dq
+#     Ip(y)   = 1/3 int_0^inf q^4 / (sqrt(q^2 + y^2) (e^q + 1)) dq
+#
+#     rho_ncdm / rho_g = (15 / pi^4) deg (T_ncdm / T_cmb)^4 a^-4 Irho(a M)
+#
+# which reduces to the familiar (7/8) (T_nu/T_gamma)^4 per family as y -> 0, since
+# Irho(0) = 7 pi^4 / 120.
+# --------------------------------------------------------------------------------------
+_IRHO_0 = 7. * np.pi**4 / 120.          # massless limit of Irho
+_IP_0 = _IRHO_0 / 3.                    # massless limit of Ip
+_ZETA3_FACTOR = 1.5 * 1.2020569031595943   # Irho(y) -> (3/2) zeta(3) y as y -> inf
+
+_LOG_Y_MIN, _LOG_Y_MAX, _N_Y = -6., 8., 2048
+
+
+def _build_ncdm_tables():
+    r"""
+    Tabulate ``Irho``, ``Ip`` and their ``y`` derivatives, by Gauss-Legendre quadrature.
+
+    The derivatives are only needed by :func:`background` with ``derivs=True`` (i.e. by
+    ``heftcamb_stability``, which needs ``d p_tot / d ln a`` to build
+    :math:`d^2\Omega_{\rm smg}/d\ln a^2`); they cost nothing to tabulate alongside.
+
+    .. code::
+
+        dIrho/dy = y   int q^2 / sqrt(q^2 + y^2) f dq
+        dIp/dy   = -y/3 int q^4 / (q^2 + y^2)^{3/2} f dq
+    """
+    # The integrands are smooth and die like e^-q; 256 nodes on [0, 40] is machine
+    # precision, and this runs once at import (a few ms).
+    x, w = np.polynomial.legendre.leggauss(256)
+    q = 20. * (x + 1.)
+    wq = 20. * w
+    f = 1. / (np.exp(q) + 1.)
+    y = np.logspace(_LOG_Y_MIN, _LOG_Y_MAX, _N_Y)
+    s = np.sqrt(q[None, :]**2 + y[:, None]**2)
+    irho = ((q**2 * f * wq)[None, :] * s).sum(axis=1)
+    ip = ((q**4 * f * wq)[None, :] / s).sum(axis=1) / 3.
+    dirho = y * ((q**2 * f * wq)[None, :] / s).sum(axis=1)
+    dip = -y / 3. * ((q**4 * f * wq)[None, :] / s**3).sum(axis=1)
+    return y, irho, ip, dirho, dip
+
+
+_NCDM_Y, _NCDM_RHO, _NCDM_P, _NCDM_DRHO, _NCDM_DP = _build_ncdm_tables()
+_NCDM_LOGY = np.log(_NCDM_Y)
+_NCDM_LOGRHO = np.log(_NCDM_RHO)
+_NCDM_LOGP = np.log(_NCDM_P)
+
+
+def _ncdm_integrals(y, derivs=False):
+    """
+    ``Irho(y), Ip(y)``, with the exact asymptotics used outside the tabulated range.
+
+    With ``derivs=True`` also returns ``y dIrho/dy, y dIp/dy`` -- the log-derivative
+    combination, which is what enters ``d rho_ncdm / d ln a``.
+    """
+    y = np.asarray(y, dtype='f8')
+    ly = np.log(np.clip(y, 1e-300, None))
+    irho = np.exp(np.interp(ly, _NCDM_LOGY, _NCDM_LOGRHO))
+    ip = np.exp(np.interp(ly, _NCDM_LOGY, _NCDM_LOGP))
+    # y below the table: fully relativistic. y above it: fully non-relativistic.
+    lo = y < _NCDM_Y[0]
+    hi = y > _NCDM_Y[-1]
+    if lo.any():
+        irho = np.where(lo, _IRHO_0, irho)
+        ip = np.where(lo, _IP_0, ip)
+    if hi.any():
+        irho = np.where(hi, _ZETA3_FACTOR * y, irho)
+        ip = np.where(hi, 0., ip)
+    if not derivs:
+        return irho, ip
+    ydirho = y * np.interp(ly, _NCDM_LOGY, _NCDM_DRHO)
+    ydip = y * np.interp(ly, _NCDM_LOGY, _NCDM_DP)
+    if lo.any():                      # relativistic: both integrals are y-independent
+        ydirho = np.where(lo, 0., ydirho)
+        ydip = np.where(lo, 0., ydip)
+    if hi.any():                      # Irho -> (3/2) zeta(3) y, Ip -> 0
+        ydirho = np.where(hi, _ZETA3_FACTOR * y, ydirho)
+        ydip = np.where(hi, 0., ydip)
+    return irho, ip, ydirho, ydip
+
+
+# --------------------------------------------------------------------------------------
+# Background
+# --------------------------------------------------------------------------------------
+def default_a_grid(na=DEFAULT_NA, a_min=A_INI, a_split=1e-3, frac_early=0.25):
+    r"""
+    The scale-factor grid the stability scan runs on: log-spaced, but in two pieces.
+
+    ``[a_min, 1]`` is 32 e-folds, and mochi_class covers it with 3000 points uniform in
+    :math:`\ln a`.  Almost all of that range carries no structure: the alphas of both
+    parametrisations are exponentially small at early times, and ``cs2num`` tends
+    smoothly to zero there.  Everything that decides the verdict happens in the last few
+    decades.  So ``frac_early`` of the points go on ``[a_min, a_split]`` and the rest on
+    ``[a_split, 1]``.
+
+    That is worth a lot.  Measured against the exact 3000-point grid over a broad prior
+    -- mean displacement of the decision boundary, in units of the prior width::
+
+        grid            hill_valley   propto_omega
+        512 uniform        1.4e-4        1.2e-4
+        512 two-part       4.9e-5        7.1e-6
+
+    i.e. for ``propto_omega`` 512 non-uniform points are worth more than 3000 uniform
+    ones, at a sixth of the cost.  :func:`class_a_grid` reproduces mochi_class' own
+    sampling exactly if you want it.
+
+    ``na`` is the total number of points, and is the main speed/fidelity dial;
+    ``validate_stability.py`` measures what thinning it costs.
+    """
+    na = int(na)
+    ne = max(2, int(na * frac_early))
+    return np.concatenate([np.logspace(np.log10(a_min), np.log10(a_split), ne, endpoint=False),
+                           np.logspace(np.log10(a_split), 0., na - ne)])
+
+
+def class_a_grid():
+    r"""mochi_class' own background sampling: 3000 points uniform in :math:`\ln a`."""
+    return np.logspace(np.log10(A_INI), 0., N_CLASS_TABLE)
+
+
+def background(a, h=0.6736, omega_b=0.02237, omega_cdm=0.12, w0=-1., wa=0.,
+               m_ncdm=0.06, deg_ncdm=1., T_ncdm=T_NCDM_DEFAULT, N_ur=2.0328,
+               T_cmb=2.7255, omega_ncdm=None, Omega_smg=None, derivs=False):
+    r"""
+    The dimensionless background combinations the stability criterion needs.
+
+    Everything is a ratio to :math:`H^2`, so no unit or :math:`H_0` convention survives
+    into the answer.  ``a`` broadcasts against the (array-valued) parameters; the usual
+    call has parameters of shape ``(n, 1)`` and ``a`` of shape ``(na,)`` or ``(n, na)``.
+
+    ``m_ncdm`` is the mass in eV of a **single** ncdm species with degeneracy
+    ``deg_ncdm`` (``deg_ncdm=3`` gives three degenerate massive neutrinos, as CLASS
+    does).  Note that ``m_ncdm=0`` is a *massless* ncdm species at ``T_ncdm``, exactly as
+    it is in CLASS -- to have no ncdm species at all, pass ``deg_ncdm=0`` (and move the
+    relativistic degrees of freedom into ``N_ur``).
+
+    ``Omega_smg`` defaults to ``None``, meaning mochi_class' closure equation
+    (``Omega_smg = -1`` in the ``.ini``): it is fixed by flatness.  Pass a number to
+    override.
+
+    Returns a dict with
+
+    ``X_m``
+        :math:`(\rho_{\rm tot,wo\,smg} + p_{\rm tot,wo\,smg}) / H^2`
+    ``X_de``
+        :math:`(\rho_{\rm smg} + p_{\rm smg}) / H^2`
+    ``Omega_de``
+        :math:`\rho_{\rm smg} / H^2` -- mochi_class' ``Omega_smg``, the shape function
+        of the ``propto_omega`` parametrisation
+    ``P_tot``
+        :math:`p_{\rm tot} / H^2`, *including* smg; only needed for
+        :math:`d\Omega_{\rm smg}/d\ln a`
+    ``w``
+        :math:`w_0 + w_a (1 - a)`
+
+    With ``derivs=True`` three more entries appear, all :math:`d/d\ln a`:
+    ``dP_tot``, ``dOmega_de`` and ``d2Omega_de``.  ``heftcamb_stability`` needs them
+    because EFTCAMB's :math:`\Omega`, and hence its gradient term, depends on
+    :math:`\alpha_T'' \propto \Omega_{\rm smg}''`.
+    """
+    a = np.asarray(a, dtype='f8')
+    h, omega_b, omega_cdm = (np.asarray(x, dtype='f8') for x in (h, omega_b, omega_cdm))
+    w0, wa = np.asarray(w0, dtype='f8'), np.asarray(wa, dtype='f8')
+    m_ncdm = np.asarray(m_ncdm, dtype='f8')
+
+    h2 = h**2
+    Om_g0 = omega_g(T_cmb) / h2
+    Om_ur0 = N_ur * 7. / 8. * (4. / 11.)**(4. / 3.) * Om_g0
+    Om_m0 = (omega_b + omega_cdm) / h2
+
+    # ncdm.  M = m / T_ncdm,0 exactly as CLASS' input.c: m_in_eV / k_B * eV / T_ncdm / T_cmb.
+    M = m_ncdm / _k_B_ * _eV_ / T_ncdm / T_cmb
+    ncdm_pref = 15. / np.pi**4 * deg_ncdm * T_ncdm**4 * Om_g0
+    if omega_ncdm is None:
+        Om_ncdm0 = ncdm_pref * _ncdm_integrals(M)[0]
+    else:
+        Om_ncdm0 = np.asarray(omega_ncdm, dtype='f8') / h2
+        # Renormalise the shape to hit the requested omega_ncdm today, as CLASS does
+        # via fnu_factor.
+        ncdm_pref = ncdm_pref * Om_ncdm0 / (ncdm_pref * _ncdm_integrals(M)[0])
+
+    if Omega_smg is None:
+        Om_de0 = 1. - Om_g0 - Om_ur0 - Om_ncdm0 - Om_m0
+    else:
+        Om_de0 = np.asarray(Omega_smg, dtype='f8')
+
+    am4 = a**-4
+    rho_g = Om_g0 * am4
+    rho_ur = Om_ur0 * am4
+    nc = _ncdm_integrals(a * M, derivs=derivs)
+    rho_ncdm = ncdm_pref * am4 * nc[0]
+    p_ncdm = ncdm_pref * am4 * nc[1]
+    rho_m = Om_m0 * a**-3
+
+    w = w0 + wa * (1. - a)
+    rho_de = Om_de0 * a**(-3. * (1. + w0 + wa)) * np.exp(3. * wa * (a - 1.))
+    p_de = w * rho_de
+
+    p_rad = (rho_g + rho_ur) / 3.
+    rho_wo = rho_g + rho_ur + rho_ncdm + rho_m
+    p_wo = p_rad + p_ncdm
+    E2 = rho_wo + rho_de
+
+    Om_de = rho_de / E2
+    P_tot = (p_wo + p_de) / E2
+    toret = {'X_m': (rho_wo + p_wo) / E2,
+             'X_de': (rho_de + p_de) / E2,
+             'Omega_de': Om_de,
+             'P_tot': P_tot,
+             'w': w,
+             'E2': E2}
+    if not derivs:
+        return toret
+
+    # d/dln a of each pressure.  Radiation goes like a^-4 so dp/dlna = -4p; the ncdm
+    # shape carries the extra y dI/dy; the fluid picks up dw/dlna = -a w_a.
+    dw = -a * wa
+    dp_rad = -4. * p_rad
+    dp_ncdm = -4. * p_ncdm + ncdm_pref * am4 * nc[3]
+    dp_de = (dw + w * (-3.) * (1. + w)) * rho_de
+    # dln E^2 / dlna = dln rho_tot / dlna = -3 (1 + P_tot)
+    toret['dP_tot'] = (dp_rad + dp_ncdm + dp_de) / E2 + 3. * P_tot * (1. + P_tot)
+    # Omega_de = rho_de / rho_tot, so dlnOmega_de/dlna = -3(1+w) + 3(1+P_tot).
+    toret['dOmega_de'] = 3. * Om_de * (P_tot - w)
+    toret['d2Omega_de'] = 3. * (toret['dOmega_de'] * (P_tot - w)
+                                + Om_de * (toret['dP_tot'] - dw))
+    return toret
+
+
+# --------------------------------------------------------------------------------------
+# alpha functions
+# --------------------------------------------------------------------------------------
+def alphas_hill_valley(a, c_M, tau, a_t, r=2., M2_ini=1.):
+    r"""
+    The hill/valley (No Slip Gravity) alphas of `arXiv:1904.12903
+    <https://arxiv.org/abs/1904.12903>`_, in closed form:
+
+    .. math::
+        \alpha_M = c_M \tanh u\ {\rm sech}^2 u, \quad u = \tfrac{\tau}{2}\ln(a/a_t),
+        \quad \alpha_B = -r\,\alpha_M, \quad \alpha_T = 0,
+        \quad M_\ast^2 = M_{\ast,\rm ini}^2 e^{-(c_M/\tau)\,{\rm sech}^2 u}.
+
+    ``d alpha_B / d ln a`` is differentiated analytically, so nothing here is sampled or
+    splined.  The ``sech``/``tanh`` are built from ``exp(-2|u|)`` exactly as
+    ``gravity_models_hill_valley_smg`` does, which keeps them exact out to
+    :math:`a = 10^{-14}` where ``cosh u`` would have overflowed.
+
+    Returns ``(alpha_B, alpha_M, alpha_T, dalpha_B/dlna, M2)``.
+    """
+    u = 0.5 * tau * np.log(a / a_t)
+    x2 = np.exp(-2. * np.abs(u))
+    opx2 = 1. + x2
+    sech2 = 4. * x2 / opx2**2
+    tanh_u = np.sign(u) * (1. - x2) / opx2
+
+    alpha_M = c_M * tanh_u * sech2
+    # d/dlna (tanh u sech^2 u) = (tau/2) sech^2 u (sech^2 u - 2 tanh^2 u)
+    dalpha_M = c_M * (0.5 * tau) * sech2 * (sech2 - 2. * tanh_u**2)
+
+    alpha_B = -r * alpha_M
+    M2 = M2_ini * np.exp(-(c_M / tau) * sech2)
+    return alpha_B, alpha_M, np.zeros_like(alpha_B), -r * dalpha_M, M2
+
+
+def alphas_propto_omega(a, lna, bg, c_b, c_m, c_t=0., M2_ini=1.):
+    r"""
+    The ``propto_omega`` alphas, :math:`\alpha_i = c_i\,\Omega_{\rm smg}(a)` with
+    :math:`\Omega_{\rm smg} = \rho_{\rm smg}/\rho_{\rm tot}` (*not* normalised to
+    :math:`\Omega_{\rm smg,0}`, matching ``gravity_models_smg.c``).
+
+    Two derivatives are needed and both are analytic in the background:
+
+    .. math::
+        \frac{d\Omega_{\rm smg}}{d\ln a} = 3\,\Omega_{\rm smg}
+            \left(\frac{p_{\rm tot}}{H^2} - w\right),
+
+    from :math:`d\ln\rho_{\rm smg}/d\ln a = -3(1+w)` and
+    :math:`d\ln\rho_{\rm tot}/d\ln a = -3(1 + p_{\rm tot}/H^2)`.
+
+    :math:`M_\ast^2` has no closed form here -- mochi_class integrates
+    :math:`d\ln M_\ast^2/d\ln a = \alpha_M` from ``a_ini`` with
+    :math:`M_\ast^2(a_{\rm ini}) = M^2_{\ast,\rm ini}` -- but the integral
+    :math:`\int \Omega_{\rm smg}\,d\ln a` is independent of ``c_m``, so one cumulative
+    trapezoid over the (sorted) grid does it.  ``lna`` must be ``log(a)``, increasing
+    along the last axis.
+
+    Returns ``(alpha_B, alpha_M, alpha_T, dalpha_B/dlna, M2)``.
+    """
+    Om = bg['Omega_de']
+    alpha_B = c_b * Om
+    alpha_M = c_m * Om
+    alpha_T = c_t * Om
+    dOm = 3. * Om * (bg['P_tot'] - bg['w'])
+
+    # cumulative trapezoid of Omega_smg d ln a, starting at 0 on the first grid point
+    dl = np.diff(lna, axis=-1)
+    integ = np.concatenate([np.zeros(Om.shape[:-1] + (1,)),
+                            np.cumsum(0.5 * (Om[..., 1:] + Om[..., :-1]) * dl, axis=-1)],
+                           axis=-1)
+    M2 = M2_ini * np.exp(c_m * integ)
+    return alpha_B, alpha_M, alpha_T, c_b * dOm, M2
+
+
+# --------------------------------------------------------------------------------------
+# The criterion itself
+# --------------------------------------------------------------------------------------
+def cs2num(alpha_B, alpha_M, alpha_T, dalpha_B_dlna, M2, X_m, X_de):
+    """
+    mochi_class' ``cs2num``, i.e. the numerator of the scalar sound speed.
+
+    Identical (to 1e-15 relative) to the ``cs2num`` column of the background table; see
+    ``gravity_functions_As_from_alphas_smg``.  Since ``D = alpha_K + 3/2 alpha_B^2 > 0``
+    for ``alpha_K > 0``, the sign of this *is* the sign of :math:`c_s^2`.
+    """
+    dM2 = M2 - 1.
+    lam2 = (-1.5 * X_m * (alpha_B - 2. * dM2 / M2)
+            - 1.5 * X_de * (alpha_B - 2.) + dalpha_B_dlna)
+    return (alpha_B - 2.) * (-alpha_B - 2. * alpha_M
+                             + 2. * alpha_T - alpha_B * alpha_T) / 2. + lam2
+
+
+def kinetic_D(alpha_K, alpha_B):
+    """``D = alpha_K + 3/2 alpha_B^2``; the scalar no-ghost test is ``D >= 0``."""
+    return alpha_K + 1.5 * alpha_B**2
+
+
+# --------------------------------------------------------------------------------------
+# Drivers
+# --------------------------------------------------------------------------------------
+_COSMO_KEYS = ('h', 'omega_b', 'omega_cdm', 'w0', 'wa', 'm_ncdm', 'deg_ncdm',
+               'T_ncdm', 'N_ur', 'T_cmb', 'omega_ncdm', 'Omega_smg')
+
+#: Per-chunk size of the (n_models, n_a) work array.  4e6 doubles is ~32 MB, which keeps
+#: the whole scan in L3/DRAM bandwidth rather than swapping.
+_CHUNK_ELEMENTS = 4_000_000
+
+
+def _broadcast(names, values):
+    """Broadcast a set of parameters to a common shape and flatten to ``(n,)`` each."""
+    arrays = [np.asarray(v, dtype='f8') for v in values]
+    shape = np.broadcast_shapes(*[x.shape for x in arrays]) if arrays else ()
+    flat = [np.broadcast_to(x, shape).reshape(-1) for x in arrays]
+    return dict(zip(names, flat)), shape, int(np.prod(shape, dtype='i8'))
+
+
+def _refined_grid(a_grid, a_t, tau, u_max=8., n_refine=96):
+    """
+    Add a per-model window of points around the hill/valley transition.
+
+    ``alpha_M`` lives entirely in ``|u| <~ 8`` (``sech^2 u = 4 e^{-2|u|}``), a window
+    whose width in ``ln a`` is ``4 u_max / tau`` -- so for large ``tau`` it is narrower
+    than the global grid spacing and would otherwise be stepped straight over.  The
+    window is clipped to ``[A_INI, 1]``, the range mochi_class actually scans; duplicate
+    points at the clip are harmless because only the minimum over the axis is used.
+    """
+    u = np.linspace(-u_max, u_max, int(n_refine))
+    a_ref = np.clip(a_t[:, None] * np.exp(2. * u[None, :] / tau[:, None]), A_INI, 1.)
+    return np.concatenate([np.broadcast_to(a_grid, (a_t.size, a_grid.size)), a_ref], axis=-1)
+
+
+def _scan(model, par, cosmo_keys, a_grid, refine, n_refine, chunk):
+    """
+    Sweep the ``a`` grid once and return every quantity mochi_class reduces over it.
+
+    One pass, because the five rejection conditions all read the same alphas: it would
+    be wasteful (and easy to let drift) to recompute them per test.
+    """
+    n = len(next(iter(par.values())))
+    lna = np.log(a_grid)
+    width = a_grid.size + (n_refine if refine else 0)
+    nchunk = chunk or max(1, _CHUNK_ELEMENTS // width)
+
+    out = {k: np.empty(n) for k in ('min_cs2num', 'min_bra', 'max_bra', 'min_ten', 'min_M2')}
+    for i in range(0, n, nchunk):
+        sl = slice(i, min(i + nchunk, n))
+        p = {k: v[sl][:, None] for k, v in par.items()}
+        bgkw = {k: p[k] for k in cosmo_keys}
+        if model == 'hill_valley':
+            a = (_refined_grid(a_grid, par['a_t'][sl], par['tau'][sl], n_refine=n_refine)
+                 if refine else a_grid)
+            bg = background(a, **bgkw)
+            al = alphas_hill_valley(a, p['c_M'], p['tau'], p['a_t'], p['r'], p['M2_ini'])
+        else:
+            bg = background(a_grid, **bgkw)
+            al = alphas_propto_omega(a_grid, lna, bg, p['c_b'], p['c_m'], p['c_t'],
+                                     p['M2_ini'])
+        aB, aM, aT, daB, M2 = al
+        out['min_cs2num'][sl] = cs2num(aB, aM, aT, daB, M2, bg['X_m'], bg['X_de']).min(axis=-1)
+        out['min_bra'][sl] = np.broadcast_to(aB, bg['X_m'].shape).min(axis=-1)
+        out['max_bra'][sl] = np.broadcast_to(aB, bg['X_m'].shape).max(axis=-1)
+        out['min_ten'][sl] = np.broadcast_to(aT, bg['X_m'].shape).min(axis=-1)
+        out['min_M2'][sl] = np.broadcast_to(M2, bg['X_m'].shape).min(axis=-1)
+    return out
+
+
+def _prepare(model, args, cosmo, na, a_grid):
+    bad = set(cosmo) - set(_COSMO_KEYS)
+    if bad:
+        raise TypeError('unexpected argument(s) {}; expected model parameters or one of {}'
+                        .format(sorted(bad), list(_COSMO_KEYS)))
+    names = list(args) + list(cosmo)
+    par, shape, n = _broadcast(names, list(args.values()) + list(cosmo.values()))
+    grid = default_a_grid(na) if a_grid is None else np.asarray(a_grid, dtype='f8')
+    return par, shape, n, grid
+
+
+def scan_hill_valley(c_M, tau, a_t, r=2., M2_ini=1., na=DEFAULT_NA, a_grid=None,
+                     refine=True, n_refine=96, chunk=None, **cosmo):
+    r"""
+    Every quantity mochi_class minimises over ``a``, for the hill/valley parametrisation.
+
+    Returns a dict of arrays -- ``min_cs2num``, ``min_bra``, ``max_bra``, ``min_ten``,
+    ``min_M2`` -- from a single sweep of the grid.  :func:`stable_hill_valley` is a thin
+    wrapper; use this directly when you want the margins rather than the verdict (for
+    instance to train a classifier on a smooth target rather than a boolean).
+    """
+    args = dict(c_M=c_M, tau=tau, a_t=a_t, r=r, M2_ini=M2_ini)
+    par, shape, n, grid = _prepare('hill_valley', args, cosmo, na, a_grid)
+    out = _scan('hill_valley', par, list(cosmo), grid, refine, n_refine, chunk)
+    return {k: (v.reshape(shape) if shape else v[0]) for k, v in out.items()}
+
+
+def scan_propto_omega(c_b, c_m, c_t=0., M2_ini=1., na=DEFAULT_NA, a_grid=None,
+                      chunk=None, **cosmo):
+    r"""
+    Every quantity mochi_class minimises over ``a``, for ``propto_omega``.
+
+    No per-model grid refinement is offered: :math:`\Omega_{\rm smg}(a)` is smooth and
+    slowly varying, so the global log grid resolves it everywhere.  The grid must stay
+    sorted because :math:`M_\ast^2` comes from a cumulative integral along it.
+    """
+    args = dict(c_b=c_b, c_m=c_m, c_t=c_t, M2_ini=M2_ini)
+    par, shape, n, grid = _prepare('propto_omega', args, cosmo, na, a_grid)
+    out = _scan('propto_omega', par, list(cosmo), grid, False, 0, chunk)
+    return {k: (v.reshape(shape) if shape else v[0]) for k, v in out.items()}
+
+
+def min_cs2num_hill_valley(c_M, tau, a_t, r=2., M2_ini=1., **kwargs):
+    r"""
+    :math:`\min_a` ``cs2num`` for the hill/valley (No Slip Gravity) parametrisation.
+
+    ``mochi_class`` takes these as
+    ``parameters_smg = [alpha_K, c_M, tau, a_t, r, M2_ini]``; ``alpha_K`` does not enter
+    the gradient test (see the module docstring) and is not an argument here.
+
+    All model and cosmological parameters broadcast against one another; the result has
+    their common shape.  Negative means mochi_class would abort with *"Gradient
+    instability for scalar field perturbations"*.  Note this is only one of the five
+    conditions mochi_class applies -- :func:`stable_hill_valley` applies all of them.
+
+    Extra keyword arguments are passed to :func:`background` (``h``, ``omega_b``,
+    ``omega_cdm``, ``w0``, ``wa``, ``m_ncdm``, ...) or control the grid (``na``,
+    ``a_grid``, ``refine``, ``n_refine``, ``chunk``).
+    """
+    return scan_hill_valley(c_M, tau, a_t, r=r, M2_ini=M2_ini, **kwargs)['min_cs2num']
+
+
+def min_cs2num_propto_omega(c_b, c_m, c_t=0., M2_ini=1., **kwargs):
+    r"""
+    :math:`\min_a` ``cs2num`` for ``propto_omega`` (:math:`\alpha_i = c_i \Omega_{\rm smg}(a)`).
+
+    ``mochi_class`` takes these as
+    ``parameters_smg = [alpha_K, c_b, c_m, c_t, M2_ini]``; ``c_k`` (:math:`\alpha_K`)
+    does not enter the gradient test and is not an argument here.  As above, this is one
+    condition of five; :func:`stable_propto_omega` applies all of them.
+    """
+    return scan_propto_omega(c_b, c_m, c_t=c_t, M2_ini=M2_ini, **kwargs)['min_cs2num']
+
+
+def _verdict(s, M2_ini, alpha_K):
+    """
+    Apply mochi_class' rejection conditions to the output of a scan.
+
+    Five conditions, four of them from ``stability_tests_smg`` and one from
+    ``background_solve_smg``:
+
+    ``min c_s^2 >= 0``
+        gradient stability of the scalar.  ``sign(c_s^2) = sign(cs2num)`` because
+        ``D > 0``; see :func:`cs2num`.
+    ``min D >= 0``
+        no scalar ghost.  Guaranteed by ``alpha_K >= 0``, checked only if ``alpha_K``
+        was supplied.
+    ``min M_*^2 >= 0``
+        no tensor ghost.
+    ``min c_t^2 = 1 + min alpha_T >= 0``
+        gradient stability of the tensors.
+    ``alpha_B does not cross 2``
+        ``class_test_except`` at ``background_smg.c:1108``.  This one is **not** gated by
+        ``skip_stability_tests_smg``: mochi_class refuses the model whatever that flag
+        says, because ``2 - alpha_B`` sits in the denominator of the perturbation
+        equations.  It is easy to miss when generating labels, since a run with
+        ``skip_stability_tests_smg='yes'`` still raises on it.
+    """
+    ok = s['min_cs2num'] >= 0.
+    ok = np.logical_and(ok, s['min_M2'] >= 0.)
+    ok = np.logical_and(ok, 1. + s['min_ten'] >= 0.)
+    ok = np.logical_and(ok, ~((s['min_bra'] < 2.) & (s['max_bra'] > 2.)))
+    ok = np.logical_and(ok, np.asarray(M2_ini, dtype='f8') > 0.)
+    if alpha_K is not None:
+        ok = np.logical_and(ok, np.asarray(alpha_K, dtype='f8') >= 0.)
+    return ok
+
+
+def stable_hill_valley(c_M, tau, a_t, r=2., M2_ini=1., alpha_K=None, **kwargs):
+    """
+    ``True`` where mochi_class would run the model, ``False`` where it would abort.
+
+    Applies all five of mochi_class' rejection conditions; see :func:`_verdict` for the
+    list and for which ones are non-trivial here.
+
+    ``alpha_K`` is optional and only ever used to reject ``alpha_K < 0``.  That is not a
+    stylistic choice: the gradient verdict is the sign of ``cs2num``, which equals the
+    sign of ``c_s^2 = cs2num / D`` **only while** ``D = alpha_K + 3/2 alpha_B^2 > 0``.
+    With ``alpha_K >= 0`` that holds identically and both the ghost and gradient tests
+    are exact.  With ``alpha_K < 0``, ``D`` can change sign and this function is no
+    longer a faithful reproduction of mochi_class, so such models are reported unstable.
+    """
+    return _verdict(scan_hill_valley(c_M, tau, a_t, r=r, M2_ini=M2_ini, **kwargs),
+                    M2_ini, alpha_K)
+
+
+def stable_propto_omega(c_b, c_m, c_t=0., M2_ini=1., alpha_K=None, **kwargs):
+    """
+    ``True`` where mochi_class would run the model, ``False`` where it would abort.
+
+    As :func:`stable_hill_valley`, including the ``alpha_K`` caveat.  Two conditions that
+    are trivial for hill/valley bite here: ``alpha_T = c_t Omega_smg`` is not identically
+    zero, so ``c_t^2 = 1 + alpha_T >= 0`` is real; and ``alpha_B = c_b Omega_smg`` runs
+    from 0 up to ``c_b Omega_smg,0``, so any ``c_b > 2 / Omega_smg,0`` (about 2.9) makes
+    the braiding cross 2 and is refused outright.
+    """
+    return _verdict(scan_propto_omega(c_b, c_m, c_t=c_t, M2_ini=M2_ini, **kwargs),
+                    M2_ini, alpha_K)
+
+
+def stable(gravity_model, parameters_smg, **cosmo):
+    """
+    Dispatch on mochi_class' own ``gravity_model`` / ``parameters_smg`` pair.
+
+    ``parameters_smg`` is an array whose **last** axis holds the parameters in
+    mochi_class' order, so a prior sample of shape ``(n, 6)`` goes straight in::
+
+        # parameters_smg = [alpha_K, c_M, tau, a_t, r, M2_ini]
+        ok = mgs.stable('hill_valley', theta, h=h, omega_cdm=omega_cdm, w0=w0, wa=wa)
+
+        # parameters_smg = [alpha_K, c_b, c_m, c_t, M2_ini]
+        ok = mgs.stable('propto_omega', theta, h=h, omega_cdm=omega_cdm, w0=w0, wa=wa)
+
+    ``'no_slip_gravity'`` is accepted as an alias of ``'hill_valley'``, as in
+    ``gravity_models_smg.c``.  Extra keyword arguments go to :func:`background`, plus
+    ``na`` / ``a_grid`` / ``refine`` / ``chunk``.
+    """
+    p = np.asarray(parameters_smg, dtype='f8')
+    if gravity_model in ('hill_valley', 'no_slip_gravity'):
+        if p.shape[-1] != 6:
+            raise ValueError('hill_valley expects parameters_smg = [alpha_K, c_M, tau, '
+                             'a_t, r, M2_ini] on the last axis, got {}'.format(p.shape))
+        aK, c_M, tau, a_t, r, M2_ini = (p[..., i] for i in range(6))
+        return stable_hill_valley(c_M, tau, a_t, r=r, M2_ini=M2_ini, alpha_K=aK, **cosmo)
+    if gravity_model == 'propto_omega':
+        if p.shape[-1] != 5:
+            raise ValueError('propto_omega expects parameters_smg = [alpha_K, c_b, c_m, '
+                             'c_t, M2_ini] on the last axis, got {}'.format(p.shape))
+        aK, c_b, c_m, c_t, M2_ini = (p[..., i] for i in range(5))
+        return stable_propto_omega(c_b, c_m, c_t=c_t, M2_ini=M2_ini, alpha_K=aK, **cosmo)
+    raise ValueError("gravity_model must be 'hill_valley' ('no_slip_gravity') or "
+                     "'propto_omega', got {!r}".format(gravity_model))

--- a/cosmoprimo/mochiclassy.py
+++ b/cosmoprimo/mochiclassy.py
@@ -1,9 +1,20 @@
 """Cosmological calculation with the Boltzmann code MochiCLASS."""
 
+import numpy as np
+
 from pyclass import mochiclass
 
 from .cosmology import BaseEngine, CosmologyInputError, CosmologyComputationError
 from . import classy
+
+
+# Input parameters that switch on the scalar-modified-gravity (smg) sector.
+_smg_parameters = ('gravity_model', 'expansion_model', 'parameters_smg', 'expansion_smg', 'Omega_smg')
+
+# Verbosity at which mochi_class writes the alpha-functions, M_*^2 and the EFT
+# combinations (cs2num, lambda_i) to the background table; required by
+# :meth:`Background.h1`, :meth:`Background.h3` and :meth:`Background.h5`.
+_output_background_smg = 3
 
 
 class MochiClassEngine(classy.ClassEngine):
@@ -15,6 +26,11 @@ class MochiClassEngine(classy.ClassEngine):
     _default_cosmological_parameters = dict()
 
     def _set_classy(self, params):
+
+        if any(name in params for name in _smg_parameters):
+            # Only raise verbosity, never lower a user-provided value.
+            params = dict(params)
+            params['output_background_smg'] = max(int(params.get('output_background_smg', 0)), _output_background_smg)
 
         class _ClassEngine(mochiclass.ClassEngine):
 
@@ -29,9 +45,147 @@ class MochiClassEngine(classy.ClassEngine):
         self.classy = _ClassEngine(params=params)
 
 
+def _flatarray(func):
+    """Decorator to make ``func(self, z)`` accept any array shape (and scalars)."""
+    from functools import wraps
+
+    @wraps(func)
+    def wrapper(self, z, *args, **kwargs):
+        z = np.asarray(z, dtype='f8')
+        toret = func(self, z.ravel(), *args, **kwargs)
+        if z.ndim == 0:
+            return toret[0]
+        return toret.reshape(z.shape)
+
+    return wrapper
+
+
 class Background(classy.BaseClassBackground, mochiclass.Background):
 
-    """Your modifications, if any."""
+    r"""
+    Background quantities, including the Horndeski / EFT-of-dark-energy functions
+    :math:`h_{1}`, :math:`h_{3}` and :math:`h_{5}` of `arXiv:1902.06978
+    <https://arxiv.org/abs/1902.06978>`_ (eqs. 64, 66, 68), which parameterize the
+    quasi-static effective Newton constant
+
+    .. math:: Y(k, z) = h_{1} \frac{1 + k^{2} h_{5}}{1 + k^{2} h_{3}}.
+
+    These require the smg sector to be switched on, e.g.::
+
+        cosmo = AbacusSummit(0, engine='mochiclass', Omega_Lambda=0, Omega_fld=0, Omega_smg=-1,
+                             gravity_model='propto_omega', parameters_smg='1., 0.5, 0.3, 0., 1.',
+                             expansion_model='wowa', expansion_smg='0.685, -1., 0.')
+        cosmo.h1(z), cosmo.h3(z), cosmo.h5(z), cosmo.Y(k, z)
+    """
+
+    def _eft_of_de(self):
+        r"""
+        Return dict of cubic splines, as a function of :math:`\ln a`, of the background
+        quantities entering eqs. (62) - (69) of arXiv:1902.06978.
+
+        All ingredients are taken directly from the mochi_class background table, so no
+        finite differencing of the alpha-functions is involved. Using primes for
+        :math:`d / d\ln a`, the required identities are:
+
+        - :math:`\xi \equiv H^{\prime} / H = -\frac{3}{2} (\rho_\mathrm{tot} + p_\mathrm{tot}) / H^{2}`
+        - :math:`\alpha_{2}` (eq. 63) is mochi_class' ``lambda_2``, and mochi_class'
+          ``cs2num`` :math:`= (2 - \alpha_{B}) \alpha_{1} / 2 + \alpha_{2}` is exactly
+          the numerator of :math:`h_{3}`;
+        - :math:`2 \xi^{2} + \xi^{\prime} + \xi (3 + \alpha_{M}) = \xi \alpha_{M} - \frac{3}{2} p_\mathrm{tot}^{\prime} / H^{2}`,
+          which removes the need for :math:`\xi^{\prime}` (hence :math:`H^{\prime\prime}`) in :math:`\mu^{2}` (eq. 69).
+        """
+        if getattr(self, '_eft_of_de_splines', None) is None:
+            from scipy import interpolate
+
+            table = self.table()
+            names = table.dtype.names or ()
+            for name in ('braiding_smg', 'cs2num'):
+                if name not in names:
+                    raise CosmologyInputError('mochi_class did not output "{}"; h1 / h3 / h5 require the smg sector, '
+                                              'i.e. one of {} among the engine parameters'.format(name, _smg_parameters))
+            z = table['z']
+            a = 1. / (1. + z)
+            H = table['H [1/Mpc]']  # H / c, in 1 / Mpc
+            H2 = H**2
+            di = {'M2': table['M*^2_smg'],
+                  'alpha_B': table['braiding_smg'],
+                  'alpha_M': table['Mpl_running_smg'],
+                  'alpha_T': table['tensor_excess_smg'],
+                  'cs2num': table['cs2num'],
+                  # xi = H' / H
+                  'xi': -1.5 * (table['(.)rho_tot'] + table['(.)p_tot']) / H2,
+                  # p_tot' / H^2, with ' = d / dln a and (.)p_tot_prime = dp_tot / dtau
+                  'dp_over_H2': table['(.)p_tot_prime'] / (a * H) / H2,
+                  # a H / c, in h / Mpc
+                  'aH': a * H / self.h}
+            loga = np.log(a)
+            argsort = np.argsort(loga)  # the table is tabulated in increasing ln(a), but let's be safe
+            loga = loga[argsort]
+            self._eft_of_de_splines = {name: interpolate.CubicSpline(loga, value[argsort], extrapolate=False)
+                                       for name, value in di.items()}
+        return self._eft_of_de_splines
+
+    def _eft_of_de_at_z(self, z):
+        """Evaluate :meth:`_eft_of_de` at redshift ``z``, and add the derived alpha_1, alpha_2, mu^2."""
+        loga = -np.log(1. + z)
+        toret = {name: spline(loga) for name, spline in self._eft_of_de().items()}
+        aB, aM, aT = toret['alpha_B'], toret['alpha_M'], toret['alpha_T']
+        # eq. 62
+        toret['alpha_1'] = alpha_1 = aB + (aB - 2.) * aT + 2. * aM
+        # eq. 63, mochi_class' lambda_2 (equivalently, cs2num - (2 - alpha_B) alpha_1 / 2)
+        toret['alpha_2'] = alpha_2 = toret['cs2num'] - (2. - aB) * alpha_1 / 2.
+        # eq. 69
+        toret['mu2'] = -3. * (aB * (toret['xi'] * aM - 1.5 * toret['dp_over_H2']) + toret['xi'] * alpha_2)
+        return toret
+
+    @_flatarray
+    def h1(self, z):
+        r"""
+        :math:`h_{1} = (1 + \alpha_{T}) / M_{\ast}^{2}`, eq. 64 of arXiv:1902.06978, unitless.
+        """
+        bg = self._eft_of_de_at_z(z)
+        return (1. + bg['alpha_T']) / bg['M2']
+
+    @_flatarray
+    def h3(self, z):
+        r"""
+        :math:`h_{3} = \left[(2 - \alpha_{B}) \alpha_{1} + 2 \alpha_{2}\right] / (2 a^{2} H^{2} \mu^{2})`,
+        eq. 66 of arXiv:1902.06978, in :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`).
+        """
+        bg = self._eft_of_de_at_z(z)
+        return bg['cs2num'] / (bg['aH']**2 * bg['mu2'])
+
+    @_flatarray
+    def h5(self, z):
+        r"""
+        :math:`h_{5} = \left[\frac{1 + \alpha_{M}}{1 + \alpha_{T}} \alpha_{1} + \alpha_{2}\right] / (a^{2} H^{2} \mu^{2})`,
+        eq. 68 of arXiv:1902.06978, in :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`).
+        """
+        bg = self._eft_of_de_at_z(z)
+        numerator = (1. + bg['alpha_M']) / (1. + bg['alpha_T']) * bg['alpha_1'] + bg['alpha_2']
+        return numerator / (bg['aH']**2 * bg['mu2'])
+
+    def Y(self, k, z):
+        r"""
+        Quasi-static effective Newton constant :math:`Y = h_{1} (1 + k^{2} h_{5}) / (1 + k^{2} h_{3})`,
+        eq. 24 of arXiv:1902.06978, unitless.
+
+        Parameters
+        ----------
+        k : array_like
+            Wavenumbers, in :math:`h/\mathrm{Mpc}`.
+
+        z : array_like
+            Redshifts.
+
+        Returns
+        -------
+        Y : array
+            Array of shape ``(k.shape, z.shape)``.
+        """
+        k, z = np.asarray(k, dtype='f8'), np.asarray(z, dtype='f8')
+        k2 = k.reshape(k.shape + (1,) * z.ndim)**2
+        return self.h1(z) * (1. + k2 * self.h5(z)) / (1. + k2 * self.h3(z))
 
 
 class Thermodynamics(classy.BaseClassThermodynamics, mochiclass.Thermodynamics):

--- a/cosmoprimo/mochiclassy.py
+++ b/cosmoprimo/mochiclassy.py
@@ -98,13 +98,16 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
           the numerator of :math:`h_{3}`;
         - :math:`2 \xi^{2} + \xi^{\prime} + \xi (3 + \alpha_{M}) = \xi \alpha_{M} - \frac{3}{2} p_\mathrm{tot}^{\prime} / H^{2}`,
           which removes the need for :math:`\xi^{\prime}` (hence :math:`H^{\prime\prime}`) in :math:`\mu^{2}` (eq. 69).
+          The :math:`3/2` (rather than :math:`1/2`) is CLASS' ``(.)`` convention: the table stores
+          :math:`8 \pi G p / 3`.  Note :math:`p_\mathrm{tot}^{\prime}` must include the smg fluid;
+          see the comment on ``dp_over_H2`` below.
         """
         if getattr(self, '_eft_of_de_splines', None) is None:
             from scipy import interpolate
 
             table = self.table()
             names = table.dtype.names or ()
-            for name in ('braiding_smg', 'cs2num'):
+            for name in ('braiding_smg', 'cs2num', '(.)p_smg_prime'):
                 if name not in names:
                     raise CosmologyInputError('mochi_class did not output "{}"; h1 / h3 / h5 require the smg sector, '
                                               'i.e. one of {} among the engine parameters'.format(name, _smg_parameters))
@@ -119,8 +122,21 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
                   'cs2num': table['cs2num'],
                   # xi = H' / H
                   'xi': -1.5 * (table['(.)rho_tot'] + table['(.)p_tot']) / H2,
-                  # p_tot' / H^2, with ' = d / dln a and (.)p_tot_prime = dp_tot / dtau
-                  'dp_over_H2': table['(.)p_tot_prime'] / (a * H) / H2,
+                  # p_tot' / H^2, with ' = d / dln a and (.)p_tot_prime = dp_tot / dtau.
+                  # mochi_class' (.)p_tot_prime EXCLUDES the smg fluid: background_functions()
+                  # accumulates dp_dloga species by species (source/background.c, l. 432 - 568)
+                  # and the smg correction is commented out at source/background.c:2517, with
+                  # the note "Never used anywhere in hiclass, because here only matter
+                  # contributions without smg are considered in dp_dlna". The missing piece is
+                  # tabulated separately as (.)p_smg_prime, in the same d / dtau convention
+                  # (factor = a * H in gravity_smg/background_smg.c:2406), and mochi_class' own
+                  # mu_p uses exactly this sum (background_smg.c:1249).
+                  #
+                  # It vanishes identically for w = -1, which is why h3 / h5 were right there
+                  # and 50%-level wrong for any w != -1; with the term restored they match the
+                  # 'heftcamb' engine to ~5e-3 % (see Projects/DESI/DESI-DR2-MG/FullShape/
+                  # h1h3h5_HEFTCAMB_vs_mochiclass_v2.ipynb).
+                  'dp_over_H2': (table['(.)p_tot_prime'] + table['(.)p_smg_prime']) / (a * H) / H2,
                   # a H / c, in h / Mpc
                   'aH': a * H / self.h}
             loga = np.log(a)

--- a/cosmoprimo/mochiclassy.py
+++ b/cosmoprimo/mochiclassy.py
@@ -46,16 +46,16 @@ class MochiClassEngine(classy.ClassEngine):
 
 
 def _flatarray(func):
-    """Decorator to make ``func(self, z)`` accept any array shape (and scalars)."""
+    """Decorator to make ``func(self, x)`` accept any array shape (and scalars)."""
     from functools import wraps
 
     @wraps(func)
-    def wrapper(self, z, *args, **kwargs):
-        z = np.asarray(z, dtype='f8')
-        toret = func(self, z.ravel(), *args, **kwargs)
-        if z.ndim == 0:
+    def wrapper(self, x, *args, **kwargs):
+        x = np.asarray(x, dtype='f8')
+        toret = func(self, x.ravel(), *args, **kwargs)
+        if x.ndim == 0:
             return toret[0]
-        return toret.reshape(z.shape)
+        return toret.reshape(x.shape)
 
     return wrapper
 
@@ -70,12 +70,17 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
 
     .. math:: Y(k, z) = h_{1} \frac{1 + k^{2} h_{5}}{1 + k^{2} h_{3}}.
 
+    :math:`h_{1}`, :math:`h_{3}` and :math:`h_{5}` are functions of
+    :math:`\eta = \ln a = -\ln (1 + z)`, the time variable the underlying splines are
+    tabulated in and the one Horndeski / EFT-of-dark-energy codes (e.g. fkptjax) integrate
+    in.  :meth:`Y` keeps taking a redshift.
+
     These require the smg sector to be switched on, e.g.::
 
         cosmo = AbacusSummit(0, engine='mochiclass', Omega_Lambda=0, Omega_fld=0, Omega_smg=-1,
                              gravity_model='propto_omega', parameters_smg='1., 0.5, 0.3, 0., 1.',
                              expansion_model='wowa', expansion_smg='0.685, -1., 0.')
-        cosmo.h1(z), cosmo.h3(z), cosmo.h5(z), cosmo.Y(k, z)
+        cosmo.h1(eta), cosmo.h3(eta), cosmo.h5(eta), cosmo.Y(k, z)
     """
 
     def _eft_of_de(self):
@@ -125,10 +130,9 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
                                        for name, value in di.items()}
         return self._eft_of_de_splines
 
-    def _eft_of_de_at_z(self, z):
-        """Evaluate :meth:`_eft_of_de` at redshift ``z``, and add the derived alpha_1, alpha_2, mu^2."""
-        loga = -np.log(1. + z)
-        toret = {name: spline(loga) for name, spline in self._eft_of_de().items()}
+    def _eft_of_de_at_eta(self, eta):
+        r"""Evaluate :meth:`_eft_of_de` at :math:`\eta = \ln a`, and add the derived alpha_1, alpha_2, mu^2."""
+        toret = {name: spline(eta) for name, spline in self._eft_of_de().items()}
         aB, aM, aT = toret['alpha_B'], toret['alpha_M'], toret['alpha_T']
         # eq. 62
         toret['alpha_1'] = alpha_1 = aB + (aB - 2.) * aT + 2. * aM
@@ -139,29 +143,32 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
         return toret
 
     @_flatarray
-    def h1(self, z):
+    def h1(self, eta):
         r"""
-        :math:`h_{1} = (1 + \alpha_{T}) / M_{\ast}^{2}`, eq. 64 of arXiv:1902.06978, unitless.
+        :math:`h_{1} = (1 + \alpha_{T}) / M_{\ast}^{2}`, eq. 64 of arXiv:1902.06978, unitless,
+        as a function of :math:`\eta = \ln a`.
         """
-        bg = self._eft_of_de_at_z(z)
+        bg = self._eft_of_de_at_eta(eta)
         return (1. + bg['alpha_T']) / bg['M2']
 
     @_flatarray
-    def h3(self, z):
+    def h3(self, eta):
         r"""
         :math:`h_{3} = \left[(2 - \alpha_{B}) \alpha_{1} + 2 \alpha_{2}\right] / (2 a^{2} H^{2} \mu^{2})`,
-        eq. 66 of arXiv:1902.06978, in :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`).
+        eq. 66 of arXiv:1902.06978, in :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`),
+        as a function of :math:`\eta = \ln a`.
         """
-        bg = self._eft_of_de_at_z(z)
+        bg = self._eft_of_de_at_eta(eta)
         return bg['cs2num'] / (bg['aH']**2 * bg['mu2'])
 
     @_flatarray
-    def h5(self, z):
+    def h5(self, eta):
         r"""
         :math:`h_{5} = \left[\frac{1 + \alpha_{M}}{1 + \alpha_{T}} \alpha_{1} + \alpha_{2}\right] / (a^{2} H^{2} \mu^{2})`,
-        eq. 68 of arXiv:1902.06978, in :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`).
+        eq. 68 of arXiv:1902.06978, in :math:`(\mathrm{Mpc}/h)^{2}` (i.e. for :math:`k` in :math:`h/\mathrm{Mpc}`),
+        as a function of :math:`\eta = \ln a`.
         """
-        bg = self._eft_of_de_at_z(z)
+        bg = self._eft_of_de_at_eta(eta)
         numerator = (1. + bg['alpha_M']) / (1. + bg['alpha_T']) * bg['alpha_1'] + bg['alpha_2']
         return numerator / (bg['aH']**2 * bg['mu2'])
 
@@ -176,7 +183,8 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
             Wavenumbers, in :math:`h/\mathrm{Mpc}`.
 
         z : array_like
-            Redshifts.
+            Redshifts.  Note :meth:`h1`, :meth:`h3` and :meth:`h5` themselves take
+            :math:`\eta = \ln a`; the conversion is done here.
 
         Returns
         -------
@@ -185,7 +193,8 @@ class Background(classy.BaseClassBackground, mochiclass.Background):
         """
         k, z = np.asarray(k, dtype='f8'), np.asarray(z, dtype='f8')
         k2 = k.reshape(k.shape + (1,) * z.ndim)**2
-        return self.h1(z) * (1. + k2 * self.h5(z)) / (1. + k2 * self.h3(z))
+        eta = -np.log(1. + z)
+        return self.h1(eta) * (1. + k2 * self.h5(eta)) / (1. + k2 * self.h3(eta))
 
 
 class Thermodynamics(classy.BaseClassThermodynamics, mochiclass.Thermodynamics):

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -78,3 +78,22 @@ Interpolators
   :members:
   :inherited-members:
   :show-inheritance:
+
+Modified-gravity stability
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+mochi_class
+^^^^^^^^^^^
+
+.. automodule:: cosmoprimo.mochiclass_stability
+  :members:
+  :inherited-members:
+  :show-inheritance:
+
+HEFTCAMB
+^^^^^^^^
+
+.. automodule:: cosmoprimo.heftcamb_stability
+  :members:
+  :inherited-members:
+  :show-inheritance:


### PR DESCRIPTION
## Summary

This PR extends the modified-gravity support in `cosmoprimo`, mainly for **HEFTCAMB** and **mochi_class**.

Main changes:

* Add support for the **hill/valley parametrization** of the EFT functions in HEFTCAMB.
* Fix HEFTCAMB parameter forwarding and handling of `w0_fld` / `wa_fld`.
* Add routines to compute the beyond-EdS kernel functions **`h1`, `h3`, and `h5`** in `mochi_class`.
* Add corresponding `h1`, `h3`, and `h5` wrappers for HEFTCAMB.
* Use **`eta = ln(a)`** as the input variable for `cosmo.h1/h3/h5`.
* Harmonize the HEFTCAMB and mochi_class implementations so that they use consistent conventions.
* Add stability utilities for both HEFTCAMB and mochi_class.
* Cross-check and validate the `h1/h3/h5` predictions from the two engines against each other.

The main goal is to provide a consistent interface for computing the time-dependent kernels and the linear power spectrum required for **beyond-EdS perturbation theory** with modified-gravity models.
